### PR TITLE
fix: path error thrown when your package manager was not found

### DIFF
--- a/benchkit/communication/__init__.py
+++ b/benchkit/communication/__init__.py
@@ -580,6 +580,12 @@ class LocalCommLayer(CommunicationLayer):
 
     def which(self, cmd: str) -> pathlib.Path | None:
         result = which(cmd=cmd)
+        
+        # If result is None, pathlib.Path will throw an error because it
+        # expects bytes or string.
+        if result is None: 
+            return None
+        
         return pathlib.Path(result)
 
 


### PR DESCRIPTION
`pathlib.Path()` only supports strings, bytes and pathlike objects. Not None. This was not checked and thus an error is thrown if the package manager was not found.

With this fix, the system will still throw an error when your package manager is not known, but it will throw the *correct* error about now knowing your package manager.

This PR resolved #4 