### PR TITLE
allow pass ignore_ret_codes while running bench

### DIFF
--- a/benchkit/benchmark.py
+++ b/benchkit/benchmark.py
@@ -695,6 +695,7 @@ class Benchmark:
         environment: Environment,
         wrapped_environment: Environment,
         print_output: bool,
+        ignore_ret_codes: Iterable[int],
         **kwargs,
     ) -> str | AsyncProcess:
         """
@@ -741,6 +742,7 @@ class Benchmark:
             current_dir=current_dir,
             environment=wrapped_environment,
             print_output=print_output,
+            ignore_ret_codes=ignore_ret_codes,
         )
         return output
 


### PR DESCRIPTION
Allow passing return codes that can be ignored while running a bench. This way a bench campaign does not end if the program returns a code different than zero but is specified in the respective list `ignore_ret_codes`.

Then, the user can define what return codes must be ignored during the program execution.