### PR TITLE
Added parameters `perf_record_options` and `perf_report_options` to the `PerfReportWrap` class init function

### DIFF
--- a/benchkit/commandwrappers/perf.py
+++ b/benchkit/commandwrappers/perf.py
@@ -531,6 +531,8 @@ class PerfReportWrap(CommandWrapper):
         call_graph: Optional[str] = "dwarf",
         stdio: bool = False,
         flamegraph_path: Optional[PathType] = None,
+        perf_record_options: Optional[List[str]] = None,
+        perf_report_options: Optional[List[str]] = None,
     ):
         super().__init__()
         self.platform = get_current_platform()
@@ -546,8 +548,8 @@ class PerfReportWrap(CommandWrapper):
         self._stdio = stdio
         self._flamegraph_path = flamegraph_path
 
-        self._perf_record_options = None
-        self._perf_report_options = None
+        self._perf_record_options = perf_record_options
+        self._perf_report_options = perf_report_options
 
     @property
     def perf_record_options(self) -> List[str]:


### PR DESCRIPTION
Make it possible to pass perf flags when using the PerfReportWrap wrapper.