### PR TITLE
Added functions to copy files/dirs from the host to the platform machine

### DIFF
--- a/benchkit/communication/__init__.py
+++ b/benchkit/communication/__init__.py
@@ -300,6 +300,29 @@ class CommunicationLayer:
         """
         raise NotImplementedError
 
+    def copy_from_host(self, source: pathlib.Path, destination: pathlib.Path) -> None:
+        """Copy a file from the host (the machine benchkit is run on), to the
+           target machine the benchmark will be performed on
+        
+        Args:
+            source (Path): The source path where the file or folder is stored.
+            destination: (Path): The destination path where the file has to be 
+                                 copied to on the remote.
+        """
+        raise NotImplementedError("Copy from host is not implemented for your remote platform")
+
+    def copy_to_host(self, source: pathlib.Path, destination: pathlib.Path) -> None:
+        """Copy a file to the host (the machine benchkit is run on), from the
+           target machine the benchmark will be performed on
+        
+        Args:
+            source (Path): The source path where the file or folder is stored on the remote.
+            destination: (Path): The destination path where the file has to be 
+                                 copied to on the host.
+        """
+        raise NotImplementedError("Copy to host is not implemented for your remote platform")
+
+
     def hostname(self) -> str:
         """Get hostname of the target host.
 
@@ -561,6 +584,12 @@ class LocalCommLayer(CommunicationLayer):
             with open(output_filename, "a") as file:
                 file.writelines([rline])
 
+    def copy_from_host(self, source: pathlib.Path, destination: pathlib.Path) -> None:
+        self.shell(["rsync", "-av", str(source), str(destination)])
+
+    def copy_to_host(self, source: pathlib.Path, destination: pathlib.Path) -> None:
+        self.shell(["rsync", "-av", str(source), str(destination)])
+
     def current_user(self) -> str:
         return os.getlogin()
 
@@ -722,6 +751,30 @@ class SSHCommLayer(CommunicationLayer):
             command=f"{prefix}tee -a {output_filename}",
             std_input=line + "\n",
         )
+
+    def _get_ssh_host_and_port(self) -> tuple[str, str]:
+        port = 22
+        host = self._host
+
+        # We do assume that the user does not specify and esoteric ssh
+        # URI's. In other words we assume ssh://[user@]host[:port]
+        
+        if host.startswith("ssh://"):
+            host = host.split("://")[1]
+            parts = host.split(":")
+            if len(parts) == 2 and parts[1].isdigit():
+                host = parts[0]
+                port = int(parts[1])
+
+        return host, port
+
+    def copy_from_host(self, source: pathlib.Path, destination: pathlib.Path) -> None:
+        host, port = self._get_ssh_host_and_port()
+        shell_out(["rsync", "-av", "--progress", "-e", f"ssh -p {port}", str(source), f"{host}:{destination}"])
+
+    def copy_to_host(self, source: pathlib.Path, destination: pathlib.Path) -> None:
+        host, port = self._get_ssh_host_and_port()
+        shell_out(["rsync", "-a", "--progress", "-e", f"ssh -p {port}", f"{host}:{source}", str(destination)])
 
     def _remote_shell_command(
         self,


### PR DESCRIPTION
Implemented `copy_from_host` and `copy_to_host` in the communication layer that allow files and directories to be copied from the host machine to the platform machine and the other way around.
This allows users to sync changes from their machine to the remote machine during benchmark setup.
For example, this is what I use in my benchmark:
```py
src = pathlib.Path(self._src_dir)
dst = pathlib.Path(self._bench_src_path)

folders_to_copy = [
    "src",
    "include",
    "benchmarking/cornell"
]

files_to_copy = [
    "build.sh",
    "CMakeLists.txt",
    "custom_config.h",
    "benchmarking/suzanne_on_table.glb"
]


# If you want to copy a folder, you need to append it with a leading / to make sure
# that the contents are not copied and that the folders are not copied into each other.
# Since pathlib does not support this (it auto strips trailing slashes), you have
# to add them manually.

for folder in folders_to_copy:
    self.platform.comm.copy_from_host(f"{src / folder}/", f"{dst / folder}/")

for file in files_to_copy:
    self.platform.comm.copy_from_host(f"{src / file}", f"{dst / file}")
```

I was a bit on the fence about whether to add this in benchkit natively by extending the Benchmark class with for example a default function "files_to_copy_before_build" that the user can override, or just provide the copy tools and leave it up to the user. I ended up going with the latter, but let me know if extending the Benchmark class is better.