### PR TITLE
Fix PerfStatWrapper incorrect CSV output

### DIFF
--- a/benchkit/commandwrappers/perf.py
+++ b/benchkit/commandwrappers/perf.py
@@ -450,7 +450,7 @@ class PerfStatWrap(CommandWrapper):
         # should contain the name of one of these events.
         with open(perf_stat_pathname, "r") as perf_stat_file:
             first_line_filter = filter(
-                lambda row: not row.strip().startswith("#") and row.strip() is not "",
+                lambda row: not row.strip().startswith("#") and row.strip() != "",
                 perf_stat_file,
             )
             row = next(first_line_filter)


### PR DESCRIPTION
It turns out that perf stat's output contains optional values in their CSV format, to make it worse some of these optional values are the first columns of the CSV. To make it even worse, they do not provide a header in their CSV output.

These optional values cause the header we assume the CSV file to be in, to become out of sync with the real header. 

Since these values are optional, I do not know if they occur only on my machine or on that of other people so to fix this I created a function that tries to align the column names we know will be in the CSV (as specified in the man page), with the values in the first row. 
We know for example that `event_name` is a column that is mandatory so if we search for the name of an event we were listening for in the first row of the CSV, we can find the index of `event_name` in the actual CSV header and thus align our header names using that knowledge.

Fixes #27.