### PR TITLE
[Bug Fix] Fix use of _wrap_command in willitscale

### DIFF
--- a/examples/willitscale/kit/willitscale.py
+++ b/examples/willitscale/kit/willitscale.py
@@ -153,6 +153,7 @@ class WillItScaleBench(Benchmark):
             environment=environment,
             cpu_order=cpu_order,
             master_thread_core=master_thread_core,
+            nb_threads=nb_threads,
             **kwargs,
         )
 


### PR DESCRIPTION
Add missing `nb_threads` parameter into call of `_wrap_command`, thus avoiding bugs where wrapper assumes only 1 thread exists.