### PR TITLE
Using getpass instead of os

### DIFF
--- a/benchkit/communication/__init__.py
+++ b/benchkit/communication/__init__.py
@@ -13,6 +13,7 @@ import os
 import os.path
 import pathlib
 import subprocess
+import getpass
 from shutil import which
 from typing import Iterable, Dict, List
 from functools import lru_cache
@@ -597,7 +598,7 @@ class LocalCommLayer(CommunicationLayer):
         self.shell(["rsync", "-azPv", str(source), str(destination)])
 
     def current_user(self) -> str:
-        return os.getlogin()
+        return getpass.getuser()
 
     def realpath(self, path: PathType) -> pathlib.Path:
         output = os.path.realpath(path)


### PR DESCRIPTION
replacing os.getlogin() with getpass.getuser() is a more general method
of getting the current user.
This would fix issue #65.

Another solution would be to remove "def current_user(self) -> str:" in
the LocalCommLayer.
This would work since the CommunicationLayer has an implementation that
seems to work for:
- wsl
- windows
- linux

I did however go with getpass.getuser() since it does not need to start
a shell environment and might be more robust.