### PR TITLE
perf-stat: json output, remote support and bug fix

### DIFF
--- a/benchkit/benchmark.py
+++ b/benchkit/benchmark.py
@@ -927,6 +927,8 @@ class Benchmark:
                 return True
 
     def _temp_record_prefix(self) -> pathlib.Path:
+        # TODO warning, does not support concurrent execution
+        # for this, need a unique record path for each benchmark run
         return pathlib.Path("/tmp/benchkit_record")
 
     def _temp_record_data_dir(self, record_data_dir: pathlib.Path):

--- a/benchkit/commandwrappers/__init__.py
+++ b/benchkit/commandwrappers/__init__.py
@@ -42,6 +42,18 @@ class CommandWrapper:
         """
         return []
 
+    def updated_environment(self, environment: Environment) -> Environment:
+        """Define a new environment based on the given environment and the new key-values to add to
+        the environment for this wrapper.
+
+        Args:
+            environment (Environment): the environment to wrap.
+
+        Returns:
+            Environment: the new environment with updated keys and values.
+        """
+        return environment
+
     def wrap(
         self,
         command: SplitCommand,
@@ -63,5 +75,6 @@ class CommandWrapper:
         """
         wrapped_command = self.command_prefix(**kwargs) + list(command)
         wrapped_environment = environment if environment is not None else {}
+        wrapped_environment = self.updated_environment(environment=wrapped_environment)
 
         return wrapped_command, wrapped_environment

--- a/scripts/all_checks.sh
+++ b/scripts/all_checks.sh
@@ -23,7 +23,7 @@ seaborn<=0.12.2
 wget<=3.2
 EOF
     cat > ./dependency-paths.txt << EOF
-benchkit
+.
 examples/benchmarksql/kit
 examples/kyotocabinet/kit
 examples/leveldb/kit

--- a/tests/campaigns/benchmarks/sleep.py
+++ b/tests/campaigns/benchmarks/sleep.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 from benchkit.benchmark import Benchmark, CommandWrapper, CommandAttachment, SharedLib, PreRunHook, PostRunHook
+from benchkit.platforms import Platform
 import pathlib
 from benchkit.utils.dir import caller_dir
 from typing import Any, Dict, List, Iterable
@@ -15,6 +16,7 @@ class SleepBench(Benchmark):
         shared_libs: Iterable[SharedLib] = (),
         pre_run_hooks: Iterable[PreRunHook] = (),
         post_run_hooks: Iterable[PostRunHook] = (),
+        platform: Platform = None,
     ) -> None:
         super().__init__(
             command_wrappers=command_wrappers,
@@ -23,6 +25,8 @@ class SleepBench(Benchmark):
             pre_run_hooks=pre_run_hooks,
             post_run_hooks=post_run_hooks,
         )
+        if platform is not None:
+            self.platform = platform
 
     @property
     def bench_src_path(self) -> pathlib.Path:


### PR DESCRIPTION
This patch adds the support for the json output (using perf stat --json option), add the support of remote for the PerfStatWrap wrapper (based on the previous PRs) and fix a bug with french locales, i.e. it was using "," instead of "." for the decimal delimiter, breaking the json output. For that, we force the locale by setting an environment variable in the PerfStatWrap wrapper (we added the mechanisms to update the environment in command wrappers).