### PR TITLE
lwchart: fix 2 bugs

### DIFF
--- a/benchkit/lwchart.py
+++ b/benchkit/lwchart.py
@@ -93,6 +93,8 @@ def _generate_chart_from_df(
     output_path = pathlib.Path(output_dir)
     while (fig_path := output_path / f"benchkit-{prefix}{timestamp}-{fig_id:02}").exists():
         fig_id += 1
+    with open(fig_path, 'x'):  # avoid overwriting if the figures aren't created yet (race issue)
+        pass
 
     fig.savefig(f"{fig_path}.png", transparent=False)
     fig.savefig(f"{fig_path}.pdf", transparent=False)
@@ -161,6 +163,10 @@ def generate_chart_from_single_csv(
             whether to fill NaN values to replace None, empty strings, etc.
             when parsing the dataset.
     """
+    if not _LIBRARIES_ENABLED:
+        _print_warning()
+        return
+
     df = None
     try:
         df = _read_csv(csv_pathname=csv_pathname, nan_replace=nan_replace)

--- a/benchkit/lwchart.py
+++ b/benchkit/lwchart.py
@@ -91,14 +91,18 @@ def _generate_chart_from_df(
     fig_id = 1
     timestamp = datetime.datetime.now(tz=datetime.timezone.utc).strftime("%Y%m%d-%H%M%S")
     output_path = pathlib.Path(output_dir)
-    while (fig_path := output_path / f"benchkit-{prefix}{timestamp}-{fig_id:02}").exists():
+    while (fig_path_png := output_path / f"benchkit-{prefix}{timestamp}-{fig_id:02}.png").exists():
         fig_id += 1
-    with open(fig_path, 'x'):  # avoid overwriting if the figures aren't created yet (race issue)
+    with open(fig_path_png, 'x'):  # avoid overwriting if the figures aren't created yet (race issue)
         pass
 
-    fig.savefig(f"{fig_path}.png", transparent=False)
+    fig.savefig(f"{fig_path_png}", transparent=False)
+    print(f'[INFO] Saving campaign figure in "{fig_path_png}"')
+
+    fig_path = pathlib.Path(fig_path_png.with_name(fig_path_png.stem))
     fig.savefig(f"{fig_path}.pdf", transparent=False)
-    print(f'[INFO] Saving campaign figure in "{fig_path}.png"')
+    print(f'[INFO] Saving campaign figure in "{fig_path}.pdf"')
+
     plt.show()
     plt.close()
 

--- a/tests/campaigns/campaign_graphs.py
+++ b/tests/campaigns/campaign_graphs.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright (C) 2024 Vrije Universiteit Brussel. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+from benchkit.campaign import CampaignCartesianProduct
+from benchkit.platforms import get_current_platform
+from tests.campaigns.benchmarks.sleep import SleepBench
+
+
+def main() -> None:
+    platform = get_current_platform()
+
+    campaign = CampaignCartesianProduct(
+        name="charts",
+        benchmark=SleepBench(platform=platform),
+        nb_runs=2,
+        variables={"duration_seconds": [1, 2]},
+        constants=None,
+        debug=False,
+        gdb=False,
+        enable_data_dir=True,
+    )
+    campaign.run()
+    campaign.generate_graph(
+        plot_name="lineplot",
+        x="duration_seconds",
+        y="duration_seconds",
+        hue="rep",
+        markers=True,
+        dashes=False,
+    )
+    campaign.generate_graph(
+        plot_name="barplot",
+        x="duration_seconds",
+        y="duration_seconds",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fix a first bug with race condition on the file system when saving the charts. Since the actual save did not completely complete before the next "filename allocation", two consecutive charts generation can get the same filename, ending up with the second chart overriding the first one. We had the creation of an empty file just after allocation to minimize the risk it happens.

Fix a second bug with lwchart crashing when the dependencies are missing when calling the function `generate_chart_from_single_csv`. Add the missing check to avoid that bug.