### PR TITLE
Add initial support for NetBSD

### DIFF
--- a/benchkit/utils/system.py
+++ b/benchkit/utils/system.py
@@ -18,6 +18,9 @@ def _get_linux_boot_args() -> str:
 def _get_windows_boot_args() -> str:
     return "<boot args fetching is unsupported on Windows>"
 
+def _get_netbsd_boot_args() -> str:
+    return "<boot args fetching is unsupported on NetBSD>"
+
 
 def get_boot_args() -> str:
     """
@@ -34,6 +37,8 @@ def get_boot_args() -> str:
             result = _get_linux_boot_args()
         case "Windows":
             result = _get_windows_boot_args()
+        case "NetBSD":
+            result = _get_netbsd_boot_args()
         case other:
             raise ValueError(f"Unsupported operating system: {other}")
     return result


### PR DESCRIPTION
Accept `NetBSD` as a string in `system.py` and return a string for the boot options.

Currently, I don't know how to figure out the real cmdline used when booting NetBSD, so in this MR the string is the same as for Windows, ie, nothing.