### PR TITLE
Add ignore_ret_code to pipe_shell

### DIFF
--- a/benchkit/communication/__init__.py
+++ b/benchkit/communication/__init__.py
@@ -57,6 +57,7 @@ class CommunicationLayer:
         command: Command,
         current_dir: Optional[PathType] = None,
         shell: bool = False,
+        ignore_ret_codes: Iterable[int] = (),
     ):
         raise NotImplementedError()
 
@@ -504,6 +505,7 @@ class LocalCommLayer(CommunicationLayer):
         current_dir: Optional[PathType] = None,
         shell: bool = True,
         print_command: bool = True,
+        ignore_ret_codes: Iterable[int] = (),
     ):
         """
             Pipe_shell allows running a command with pipe (e.g., "ls | grep test").
@@ -515,6 +517,7 @@ class LocalCommLayer(CommunicationLayer):
             current_dir=current_dir,
             shell=shell,
             print_command=print_command,
+            ignore_ret_codes=ignore_ret_codes,
         )
 
     def shell(
@@ -717,6 +720,7 @@ class SSHCommLayer(CommunicationLayer):
         current_dir: Optional[PathType] = None,
         shell: bool = False,
         print_command: bool = True,
+        ignore_ret_codes: Iterable[int] = (),
     ):
         """
             Pipe_shell allows running a command with pipe (e.g., "ls | grep test").
@@ -744,6 +748,7 @@ class SSHCommLayer(CommunicationLayer):
             current_dir=None,
             shell=shell,
             print_command=print_command,
+            ignore_ret_codes=ignore_ret_codes,
         )
 
         return output

--- a/benchkit/shell/shell.py
+++ b/benchkit/shell/shell.py
@@ -17,6 +17,7 @@ def pipe_shell_out(
     current_dir: Optional[PathType] = None,
     shell: bool = True,
     print_command: bool = True,
+    ignore_ret_codes: Iterable[int] = (),
 ) -> str:
     """
     Run a command that is a composition of shell through pipes.
@@ -46,7 +47,22 @@ def pipe_shell_out(
             asynced=False,
             remote_host=None,
         )
-    return subprocess.check_output(command, cwd=current_dir, shell=shell, text=True)
+
+    try:
+        output = subprocess.check_output(
+            command,
+            cwd=current_dir,
+            shell=shell,
+            text=True
+        )
+
+    except subprocess.CalledProcessError as err:
+        retcode = err.returncode
+        if retcode not in ignore_ret_codes:
+            raise err
+        output = err.output
+
+    return output
 
 
 def shell_out(


### PR DESCRIPTION
Allow option to ignore a list of return codes for pipe_shell call.
Code utilized is equivalent to `ignore_ret_code` in sheel function.