### PR TITLE
Allow pinning CPUs using TaksetWrap

### DIFF
--- a/benchkit/commandwrappers/taskset.py
+++ b/benchkit/commandwrappers/taskset.py
@@ -45,22 +45,27 @@ class TasksetWrap(CommandWrapper):
 
         mtc = master_thread_core
 
-        if mtc is None:
-            if cpu_order is None:
+        if self.set_all_cpus:
+            if cpu_order is None or nb_threads is None:
                 return []
 
             cpu_order_list = self.platform.cpu_order(provided_order=cpu_order)
 
-            mtc = self.platform.master_thread_core_id(
-                cpu_order_list=cpu_order_list,
-            )
-
-        if self.set_all_cpus and nb_threads is not None:
             cpu_order_list = [str(x) for x in cpu_order_list[0:nb_threads]]
             cpu_order_str = ','.join(cpu_order_list)
 
             cmd_prefix = ["taskset", "--cpu-list", cpu_order_str] + cmd_prefix
         else:
+            if mtc is None:
+                if cpu_order is None:
+                    return []
+
+                cpu_order_list = self.platform.cpu_order(provided_order=cpu_order)
+
+                mtc = self.platform.master_thread_core_id(
+                    cpu_order_list=cpu_order_list,
+                )
+
             cmd_prefix = ["taskset", "--cpu-list", str(mtc)] + cmd_prefix
 
         return cmd_prefix

--- a/examples/leveldb/kit/leveldb.py
+++ b/examples/leveldb/kit/leveldb.py
@@ -217,6 +217,7 @@ class LevelDBBench(Benchmark):
             environment=environment,
             cpu_order=cpu_order,
             master_thread_core=master_thread_core,
+            nb_threads=nb_threads,
             **kwargs,
         )
 


### PR DESCRIPTION
Add option of `set_all_cpus` which sets the CPU affinity for all threads running.
This requires that the benchmark being used passes `nb_threads` to the command_wrapper.

If `set_all_cpus` is not set or `nb_threads` is not given, then keeps previous behavior -- that is, pinning only the master thread.