### PR TITLE
Allow SIGTERM kill of remote aync calls

### DIFF
--- a/benchkit/communication/__init__.py
+++ b/benchkit/communication/__init__.py
@@ -184,6 +184,7 @@ class CommunicationLayer:
         stderr: PathType,
         cwd: PathType | None,
         env: dict | None,
+        establish_new_connection: bool = False,
     ) -> subprocess.Popen:
         """Start a background process with the provided command.
 
@@ -552,6 +553,7 @@ class LocalCommLayer(CommunicationLayer):
         stderr: PathType,
         cwd: PathType | None,
         env: dict | None,
+        establish_new_connection: bool = False,
     ) -> subprocess.Popen:
         # Create background process in its own group id using os.setsid
         # This allows to easily kill all children of this background process
@@ -695,10 +697,12 @@ class SSHCommLayer(CommunicationLayer):
         stderr: PathType,
         cwd: PathType | None,
         env: dict | None,
+        establish_new_connection: bool = False,
     ) -> subprocess.Popen:
         full_command = self._remote_shell_command(
             remote_command=command,
             remote_current_dir=cwd,
+            establish_new_connection=establish_new_connection,
         )
 
         # Create background process in its own group id using os.setsid
@@ -870,6 +874,7 @@ class SSHCommLayer(CommunicationLayer):
         self,
         remote_command: Command,
         remote_current_dir: PathType | None = None,
+        establish_new_connection: bool = False,
     ) -> SplitCommand:
         remote_command = remote_shell_command(
             remote_command=remote_command,
@@ -878,6 +883,10 @@ class SSHCommLayer(CommunicationLayer):
 
         full_command = [
             "ssh",
+            "-oControlPath=none",
+        ] if establish_new_connection else ["ssh"]
+
+        full_command = full_command + [
             "-t",
             self._host,
             remote_command,

--- a/benchkit/shell/shellasync.py
+++ b/benchkit/shell/shellasync.py
@@ -182,8 +182,10 @@ class AsyncProcess:
         # Kill assynchronous process and all processes on the same group id
         # As we create a new group id for each background process, this will kill its children
 
-        remote_pid = self.find_matching_ssh(self._process.pid)
-        self.kill_remote_process_hierarchy(remote_pid)
+        # If using a remote call, kill the remote process
+        if self._platform.comm.remote_host() is not None:
+            remote_pid = self.find_matching_ssh(self._process.pid)
+            self.kill_remote_process_hierarchy(remote_pid)
 
         os.killpg(os.getpgid(self._process.pid), signal.SIGTERM)
         self._process.wait()

--- a/benchkit/shell/shellasync.py
+++ b/benchkit/shell/shellasync.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from typing import Optional
 
-from benchkit.platforms import Platform
+from benchkit.platforms import Platform, get_current_platform
 from benchkit.shell.utils import get_args, print_header
 from benchkit.utils.types import Command, Environment, PathType, SplitCommand
 
@@ -51,6 +51,7 @@ class AsyncProcess:
             stderr=self._stderr_handle,
             cwd=current_dir,
             env=environment,
+            establish_new_connection=True,
         )
 
     @property
@@ -122,6 +123,44 @@ class AsyncProcess:
                 returncode=self._error_code,
             )
 
+    def find_matching_ssh(self, local_pid):
+        line = get_current_platform().comm.pipe_shell(
+            command=f"netstat -tp | grep {local_pid}" + " | awk '{print $4}'",
+            print_command = False,
+        )
+        port = line.split(':')[-1].split('\n')[0]
+
+        line = self._platform.comm.pipe_shell(
+            command=f"sudo netstat -tp | grep {port}" + " | awk '{print $7}'",
+            print_command = False,
+        )
+
+        remote_pid = line.split('/')[0].split('\n')[0]
+
+        return remote_pid
+
+    def kill_remote_process_hierarchy(self, remote_pid):
+
+        children = self._platform.comm.pipe_shell(
+            command=f"ps -o pid= --ppid {remote_pid}",
+            print_command = False,
+            ignore_ret_codes = [1],
+        )
+
+        if children != "":
+
+            children = children.strip().split(' ')
+
+            for child in children:
+                self.kill_remote_process_hierarchy(child)
+
+        self._platform.comm.pipe_shell(
+            command=f"sudo kill {remote_pid}",
+            print_command = False,
+            ignore_ret_codes = [1],
+        )
+
+
     def stop(self) -> None:
         """
         Stop a running asynchronous process.
@@ -142,6 +181,10 @@ class AsyncProcess:
 
         # Kill assynchronous process and all processes on the same group id
         # As we create a new group id for each background process, this will kill its children
+
+        remote_pid = self.find_matching_ssh(self._process.pid)
+        self.kill_remote_process_hierarchy(remote_pid)
+
         os.killpg(os.getpgid(self._process.pid), signal.SIGTERM)
         self._process.wait()
 


### PR DESCRIPTION
Previous implementation kills the `ssh -t <remote> <async>` command, which will generate a soft SIGTERM kill signal in the local process but a stronger signal on the remote asynchronous call.

For benchmarks/calls with a cleanup "graceful" exit, a SIGTERM signal should be sent directly for the asynchronous call.

This benchmark creates an individual `sshd` link only for the asynchronous call, which is then used to find the remote pid and kill it -- thus guaranteeing a graceful exit.