### PR TITLE
Adding a post_run_hook to TraceCmd

### DIFF
--- a/benchkit/commandattachments/tracecmd.py
+++ b/benchkit/commandattachments/tracecmd.py
@@ -32,7 +32,7 @@ class TraceCmd:
             command.extend(["-e", event])
 
         # Add the PID and output file arguments
-        command.extend(["-P", f"{pid}", "-o", f"{out_file}"])
+        command.extend(["-P", f"{self.pid}", "-o", f"{out_file}"])
 
         AsyncProcess(
             platform=self.platform,

--- a/benchkit/commandattachments/tracecmd.py
+++ b/benchkit/commandattachments/tracecmd.py
@@ -13,6 +13,7 @@ class TraceCmd:
     def __init__(self, events: List[str] = (), platform: Platform = None,) -> None:
         self.events = [str(e) for e in events]
         self.platform = platform if platform is not None else get_current_platform()
+        self.pid = None
         
     def attachement(
         self,
@@ -23,7 +24,7 @@ class TraceCmd:
         rdd = pathlib.Path(record_data_dir)
         out_file = rdd / "trace.dat"
 
-        pid = process.pid
+        self.pid = process.pid
         command = ["sudo", "trace-cmd", "record"]
 
         # Add "-e" and each event to the command list
@@ -40,3 +41,23 @@ class TraceCmd:
             stderr_path=rdd / "trace-cmd.err",
             current_dir=rdd,
         )
+
+    def post_run_hook(
+        self,
+        record_data_dir: PathType,
+        **kwargs
+        ) -> None:
+        
+        rdd = pathlib.Path(record_data_dir)
+        print(rdd)
+        
+        command = ["trace-cmd", "report", "trace.dat"]
+            
+        AsyncProcess(
+            platform=self.platform,
+            arguments=command,
+            stdout_path=rdd / "generate-graph.out",
+            stderr_path=rdd / "generate-graph.err",
+            current_dir=rdd,
+        )
+        

--- a/tests/campaigns/campaign_tracecmd.py
+++ b/tests/campaigns/campaign_tracecmd.py
@@ -4,8 +4,6 @@
 
 from benchmarks.cprogram import CProgramBench
 from benchkit.campaign import CampaignIterateVariables
-from benchkit.shell.shellasync import AsyncProcess
-from benchkit.utils.types import PathType
 from benchkit.platforms import get_current_platform
 from benchkit.commandattachments.tracecmd import TraceCmd
 
@@ -17,7 +15,7 @@ def main() -> None:
     CampaignIterateVariables(
         name="attach",
         benchmark=CProgramBench(
-            command_attachments=[traceCmd.attachement],
+            command_attachments=[traceCmd.attachment],
             post_run_hooks=[traceCmd.post_run_hook]
         ),
         nb_runs=1,

--- a/tests/campaigns/campaign_tracecmd.py
+++ b/tests/campaigns/campaign_tracecmd.py
@@ -13,10 +13,12 @@ from benchkit.commandattachments.tracecmd import TraceCmd
 def main() -> None:
     platform = get_current_platform()
 
+    traceCmd = TraceCmd(["sched"], platform)
     CampaignIterateVariables(
         name="attach",
         benchmark=CProgramBench(
-            command_attachments=[TraceCmd(["sched"], platform).attachement],
+            command_attachments=[traceCmd.attachement],
+            post_run_hooks=[traceCmd.post_run_hook]
         ),
         nb_runs=1,
         variables=[{}],


### PR DESCRIPTION
Adding a post_run_hook to TraceCmd.

This post_run_hook can be used to do processing of the data generated by trace-cmd.