### PR TITLE
Example: fixes for libsmctrl

### DIFF
--- a/examples/gpu_scheduling/README.md
+++ b/examples/gpu_scheduling/README.md
@@ -1,46 +1,76 @@
-## GPU Scheduling and libsmctrl
-NVIDIA GPUs consist of multiple GPC (General Processing Clusters) which contain 16 TPC (Thread Processing Clusters) containing each 2 SM (Streaming Multiprocessors)
-Using libsmctrl it is possible to partition kernels across separate GPC and TPC.
-This means 2 concurrently running kernels do not compete for computation time on the same SM.
-This benchkit campaign serves to benchmark and analyze the scheduling behavior of NVIDIA GPUs using this library.
-This campaign is based on the [rtas23](https://www.cs.unc.edu/~jbakita/rtas23) and [rtas24](https://www.cs.unc.edu/~jbakita/rtas24) papers and their respective artifact evaluations [rtas23-ae](https://www.cs.unc.edu/~jbakita/rtas23-ae) and [rtas24-ae](https://www.cs.unc.edu/~jbakita/rtas24-ae).
+# GPU Scheduling and libsmctrl
 
-# Necessary Dependencies and Hardware
+NVIDIA GPUs consist of multiple GPC (General Processing Clusters) which contain
+16 TPC (Thread Processing Clusters) containing each 2 SM (Streaming
+Multiprocessors).
+Using `libsmctrl`, it is possible to partition kernels across separate GPC and
+TPC.
+This means 2 concurrently running kernels do not compete for computation time on
+the same SM.
+This benchkit campaign serves to benchmark and analyze the scheduling behavior
+of NVIDIA GPUs using this library.
+This campaign is based on the
+[rtas23](https://www.cs.unc.edu/~jbakita/rtas23)
+and
+[rtas24](https://www.cs.unc.edu/~jbakita/rtas24)
+papers and their respective artifact evaluations
+[rtas23-ae](https://www.cs.unc.edu/~jbakita/rtas23-ae)
+and
+[rtas24-ae](https://www.cs.unc.edu/~jbakita/rtas24-ae).
+
+## Necessary Dependencies and Hardware
 This campaign can only be run under certain circumstances.
-The necessary dependencies and hardware for these circumstances are detailed below.
+The necessary dependencies and hardware for these circumstances are detailed
+below.
 
-## Dependencies
+### Dependencies
 - Any standard Linux kernel should work
-    - This campaign was tested on Void Linux with kernel versions 4.19.304_1, 5.15.161_1, and 6.6.46_1
+    - This campaign was tested on Void Linux with kernel versions
+      4.19.304_1, 5.15.161_1, and 6.6.46_1.
 - Benchkit and its dependencies
     - Installed by running configure.sh
 - Docker
-    - The benchmarks run in a docker container with a predetermined version of CUDA
+    - The benchmarks run in a docker container with a predetermined version of
+      CUDA.
 - [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
-    - This is necessary for GPU passthrough of docker to work
+    - This is necessary for GPU passthrough of docker to work.
 - An NVIDIA driver version inferior to 535.129.03 and superior to 450.80.02
     - This campaign was tested on driver version 470.239.06
 
-The NVIDIA driver requirements are not hard requirements and can potentially change.
-The upper bound driver is 535.129.03 because libsmctrl does not implement SM masking for CUDA versions greater than 12.1 as those versions use a larger mask in order to support larger GPUs.
-The lower bound driver is determined by the CUDA version used in the Docker container, which is 11.4.3.
-The [support matrix](https://docs.nvidia.com/deeplearning/cudnn/latest/reference/support-matrix.html) and [cuda compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/contents.html) web pages contain information on which CUDA versions are compatible with which drivers.
-All CUDA docker containers can be found at [docker hub](https://hub.docker.com/r/nvidia/cuda/tags).
-If you want to change the CUDA version and/or driver version your are using, make sure to check these URLs.
-Another potential problem is compute capabilities.
-Depending on the driver version and CUDA version some compute capabilities may no longer work.
-More information about compute capabilities at the [CUDA documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities).
-As such changing drivers or CUDA versions means it is also necessary to modify the Makefile of [cuda_scheduling_examiner](https://github.com/JoshuaJB/cuda_scheduling_examiner_mirror).
+The NVIDIA driver requirements are not hard requirements and can potentially
+change.
+The upper bound driver is 535.129.03 because `libsmctrl` does not implement SM
+masking for CUDA versions greater than 12.1 as those versions use a larger mask
+in order to support larger GPUs.
+The lower bound driver is determined by the CUDA version used in the Docker
+container, which is 11.4.3.
+The
+[support matrix](https://docs.nvidia.com/deeplearning/cudnn/latest/reference/support-matrix.html)
+and
+[cuda compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/contents.html)
+web pages contain information on which CUDA versions are compatible with which
+drivers.
+All CUDA docker containers can be found on
+[docker hub](https://hub.docker.com/r/nvidia/cuda/tags).
+If you want to change the CUDA version and/or driver version you are using, make
+sure to check these URLs.
+Another potential problem is compute capabilities: depending on the driver
+version and CUDA version some compute capabilities may no longer work.
+More information about compute capabilities can be found in the
+[CUDA documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities).
+As such changing drivers or CUDA versions means it is also necessary to modify the Makefile of
+[cuda_scheduling_examiner](https://github.com/JoshuaJB/cuda_scheduling_examiner_mirror).
 
 ### Modifying the Makefile
-To modify the Makefile of [cuda_scheduling_examiner](https://github.com/JoshuaJB/cuda_scheduling_examiner_mirror) follow these steps.
+To modify the Makefile of `cuda_scheduling_examiner`, follow these steps.
 
 Clone the repository using the following command.
 ```sh
 git clone https://github.com/JoshuaJB/cuda_scheduling_examiner_mirror.git -b rtas23-ae
 ```
 
-Modify lines 8 and 15 through 23 as necessary and create a patch file.
+In the `Makefile`, modify lines 8 and 15 through 23 as necessary and create a
+patch file.
 ```sh
 git diff > cuda_scheduling_examiner_mirror_makefile.patch
 ```
@@ -48,7 +78,7 @@ git diff > cuda_scheduling_examiner_mirror_makefile.patch
 Place this patch file in the `patches` directory of this campaign.
 This patch should automatically be applied.
 
-## Hardware
+### Hardware
 Currently, only NVIDIA GPUs of the following architecture are supported.
 
 - Kepler
@@ -61,25 +91,27 @@ Currently, only NVIDIA GPUs of the following architecture are supported.
 This campaign was ran on an NVIDIA RTX 3060, which uses the Ampere architecture.
 
 
-# Running the Campaign
+## Running the Campaign
 In order to run this campaign follow these steps.
 
 ```sh
 ./configure.sh
 source ./venv/bin/activate
-./campaign.sh
+./campaign_libsmctrl.py
 ```
 
-# Variables
+### Variables
 The following build variables are available:
 
-- **kernel_names**: The names of the kernels to execute (excluding the file extension)
-- **cthread_counts**: The number of CUDA threads to use for each kernel
-- **block_counts**: The number of CUDA blocks to use for each kernel
-- **additional_infos**: The additional info provided to each kernel
-- **release_times**: The time at which the kernels should be released respectively
-- **sm_masks**: The SM masks that should be used for each kernel respectively
-- **iterations**: The number of iterations that should be performed
+- **kernel_names**: The names of the kernels to execute (excluding the file
+  extension),
+- **cthread_counts**: The number of CUDA threads to use for each kernel,
+- **block_counts**: The number of CUDA blocks to use for each kernel,
+- **additional_infos**: The additional info provided to each kernel,
+- **release_times**: The time at which the kernels should be released
+  respectively,
+- **sm_masks**: The SM masks that should be used for each kernel respectively,
+- **iterations**: The number of iterations that should be performed.
 
 Besides iterations, all of these variables can consist of a list of tuples.
 This is because a configuration can run multiple kernels at once.
@@ -96,7 +128,6 @@ variables={
     "sm_masks": [("0xffffffffffffffe0","0xfffffffffffff01f")],
     "iterations": [1],
 },
-
 ```
 
 In this configuration, a single config is generated.
@@ -105,8 +136,9 @@ The first kernel runs on 20 CUDA blocks while the second runs on only 8.
 The second kernel is also released 0.1 seconds later than the first.
 The SM masks also differ across the 2 kernels.
 
-In case an array is to be provided to a kernel, the array should be expressed as a tuple as well.
-The following code shows an example of this this.
+In case an array is to be provided to a kernel, the array should be expressed as
+a tuple as well.
+The following code shows an example of this.
 
 ```python
 variables={
@@ -114,142 +146,18 @@ variables={
     "cthread_counts": [((32,32),(32,32))],
     ...
 },
-
 ```
 
-This specifies 2 multidimensional thread counts for 2 separate kernels in 1 configuration.
+This specifies 2 multidimensional thread counts for 2 separate kernels in 1
+configuration.
 
-# Links
-- [libsmctrl](http://rtsrv.cs.unc.edu/cgit/cgit.cgi/libsmctrl.git/)
-- [cuda_scheduling_examiner](https://github.com/JoshuaJB/cuda_scheduling_examiner_mirror)
-- [nvdebug](http://rtsrv.cs.unc.edu/cgit/cgit.cgi/nvdebug.git)
- GPU Scheduling and libsmctrl
-NVIDIA GPUs consist of multiple GPC (General Processing Clusters) which contain 16 TPC (Thread Processing Clusters) containing each 2 SM (Streaming Multiprocessors)
-Using libsmctrl it is possible to partition kernels across separate GPC and TPC.
-This means 2 concurrently running kernels do not compete for computation time on the same SM.
-This benchkit campaign serves to benchmark and analyze the scheduling behavior of NVIDIA GPUs using this library.
-This campaign is based on the [rtas23](https://www.cs.unc.edu/~jbakita/rtas23) and [rtas24](https://www.cs.unc.edu/~jbakita/rtas24) papers and their respective artifact evaluations [rtas23-ae](https://www.cs.unc.edu/~jbakita/rtas23-ae) and [rtas24-ae](https://www.cs.unc.edu/~jbakita/rtas24-ae).
+### Adding New Variables
+In order to add a variable to the config generator it must be added to the
+variables dictionary and build variables list.
+The file `generate_config.py` should be modified to use the new variable when
+generating a configuration JSON.
 
-# Necessary Dependencies and Hardware
-This campaign can only be run under certain circumstances.
-The necessary dependencies and hardware for these circumstances are detailed below.
-
-## Dependencies
-- Any standard Linux kernel should work
-    - This campaign was tested on Void Linux with kernel versions 4.19.304_1, 5.15.161_1, and 6.6.46_1
-- Benchkit and its dependencies
-    - Installed by running configure.sh
-- Docker
-    - The benchmarks run in a docker container with a predetermined version of CUDA
-- [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
-    - This is necessary for GPU passthrough of docker to work
-- An NVIDIA driver version inferior to 535.129.03 and superior to 450.80.02
-    - This campaign was tested on driver version 470.239.06
-
-The NVIDIA driver requirements are not hard requirements and can potentially change.
-The upper bound driver is 535.129.03 because libsmctrl does not implement SM masking for CUDA versions greater than 12.1 as those versions use a larger mask in order to support larger GPUs.
-The lower bound driver is determined by the CUDA version used in the Docker container, which is 11.4.3.
-The [support matrix](https://docs.nvidia.com/deeplearning/cudnn/latest/reference/support-matrix.html) and [cuda compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/contents.html) web pages contain information on which CUDA versions are compatible with which drivers.
-All CUDA docker containers can be found at [docker hub](https://hub.docker.com/r/nvidia/cuda/tags).
-If you want to change the CUDA version and/or driver version your are using, make sure to check these URLs.
-Another potential problem is compute capabilities.
-Depending on the driver version and CUDA version some compute capabilities may no longer work.
-More information about compute capabilities at the [CUDA documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities).
-As such changing drivers or CUDA versions means it is also necessary to modify the Makefile of [cuda_scheduling_examiner](https://github.com/JoshuaJB/cuda_scheduling_examiner_mirror).
-
-### Modifying the Makefile
-To modify the Makefile of [cuda_scheduling_examiner](https://github.com/JoshuaJB/cuda_scheduling_examiner_mirror) follow these steps.
-
-Clone the repository using the following command.
-```sh
-git clone https://github.com/JoshuaJB/cuda_scheduling_examiner_mirror.git -b rtas23-ae
-```
-
-Modify lines 8 and 15 through 23 as necessary and create a patch file.
-```sh
-git diff > cuda_scheduling_examiner_mirror_makefile.patch
-```
-
-Place this patch file in the `patches` directory of this campaign.
-This patch should automatically be applied.
-
-## Hardware
-Currently, only NVIDIA GPUs of the following architecture are supported.
-
-- Kepler
-- Maxwell
-- Pascal
-- Volta
-- Turing
-- Ampere
-
-This campaign was ran on an NVIDIA RTX 3060, which uses the Ampere architecture.
-
-
-# Running the Campaign
-In order to run this campaign follow these steps.
-
-```sh
-./configure.sh
-source ./venv/bin/activate
-./campaign.sh
-```
-
-# Variables
-The following build variables are available:
-
-- **kernel_names**: The names of the kernels to execute (excluding the file extension)
-- **cthread_counts**: The number of CUDA threads to use for each kernel
-- **block_counts**: The number of CUDA blocks to use for each kernel
-- **additional_infos**: The additional info provided to each kernel
-- **release_times**: The time at which the kernels should be released respectively
-- **sm_masks**: The SM masks that should be used for each kernel respectively
-- **iterations**: The number of iterations that should be performed
-
-Besides iterations, all of these variables can consist of a list of tuples.
-This is because a configuration can run multiple kernels at once.
-These kernels may need to be given different parameters.
-The following configuration illustrates this.
-
-```python
-variables={
-    "kernel_names": [("timer_spin", "timer_spin")],
-    "cthread_counts": [(1024,1024)],
-    "block_counts": [(20,8)],
-    "additional_infos": [(250000000,250000000)],
-    "release_times": [(0, 0.1)],
-    "sm_masks": [("0xffffffffffffffe0","0xfffffffffffff01f")],
-    "iterations": [1],
-},
-
-```
-
-In this configuration, a single config is generated.
-This config executes 2 "timer_spin" kernels with each 1024 CUDA threads.
-The first kernel runs on 20 CUDA blocks while the second runs on only 8.
-The second kernel is also released 0.1 seconds later than the first.
-The SM masks also differ across the 2 kernels.
-
-In case an array is to be provided to a kernel, the array should be expressed as a tuple as well.
-The following code shows an example of this this.
-
-```python
-variables={
-    ...
-    "cthread_counts": [((32,32),(32,32))],
-    ...
-},
-
-```
-
-This specifies 2 multidimensional thread counts for 2 separate kernels in 1 configuration.
-
-
-## Adding New Variables
-In order to add a variable to the config generator it must be added to the variables dictionary and build variables list.
-The file `generate_config.py` should be modified to use the new variable when generating a configuration JSON.
-
-# Links
+## Links
 - [libsmctrl](http://rtsrv.cs.unc.edu/cgit/cgit.cgi/libsmctrl.git/)
 - [cuda_scheduling_examiner](https://github.com/JoshuaJB/cuda_scheduling_examiner_mirror)
 - [nvdebug](http://rtsrv.cs.unc.edu/cgit/cgit.cgi/nvdebug.git)

--- a/examples/gpu_scheduling/patches/cuda_scheduling_examiner_mirror_makefile.patch
+++ b/examples/gpu_scheduling/patches/cuda_scheduling_examiner_mirror_makefile.patch
@@ -1,0 +1,28 @@
+diff --git a/Makefile b/Makefile
+index 03be938..bfe7b60 100644
+--- a/Makefile
++++ b/Makefile
+@@ -5,7 +5,7 @@
+ LIBSMCTRL_PATH = ../libsmctrl
+ 
+ CFLAGS := -Wall -Werror -O3 -g -fPIC
+-NVCC ?= /usr/local/cuda-11.4/bin/nvcc
++NVCC ?= /usr/local/cuda/bin/nvcc
+ 
+ ifdef LIBSMCTRL_PATH
+ LDFLAGS += -L$(LIBSMCTRL_PATH) -lsmctrl -lcuda
+@@ -13,13 +13,7 @@ CFLAGS += -I$(LIBSMCTRL_PATH) -DSMCTRL
+ endif
+ 
+ NVCCFLAGS := -g --ptxas-options=-v --compiler-options="$(CFLAGS)" \
+-	--generate-code arch=compute_35,code=[compute_35,sm_35] \
+-	--generate-code arch=compute_50,code=[compute_50,sm_50] \
+-	--generate-code arch=compute_53,code=[compute_53,sm_53] \
+-	--generate-code arch=compute_60,code=[compute_60,sm_60] \
+-	--generate-code arch=compute_62,code=[compute_62,sm_62] \
+-	--generate-code arch=compute_70,code=[compute_70,sm_70] $(LDFLAGS)
+-#	--generate-code arch=compute_30,code=[compute_30,sm_30] \
++	--generate-code arch=compute_75,code=[compute_75,sm_75] $(LDFLAGS)
+ #	--cudart=shared \
+ 
+ BENCHMARK_DEPENDENCIES := src/library_interface.h \


### PR DESCRIPTION
Remove duplication in README, rephrased some sentences. Reduce the data sizes of the benchmark (was otherwise failing) and remove sanitization of docker paths (was otherwise not generating the scheduling charts).