### PR TITLE
trace-cmd: fix issue in post run hook

### DIFF
--- a/benchkit/commandattachments/tracecmd.py
+++ b/benchkit/commandattachments/tracecmd.py
@@ -54,7 +54,7 @@ class TraceCmd:
         print(rdd)
 
         self._process.wait()
-        
+
         command = ["trace-cmd", "report", "trace.dat"]
                 
         output = self._platform.comm.shell(

--- a/benchkit/commandattachments/tracecmd.py
+++ b/benchkit/commandattachments/tracecmd.py
@@ -7,7 +7,6 @@ from benchkit.shell.shellasync import AsyncProcess
 from benchkit.utils.types import PathType
 from benchkit.platforms import get_current_platform, Platform
 import pathlib
-import time
 
 
 class TraceCmd:

--- a/benchkit/commandattachments/tracecmd.py
+++ b/benchkit/commandattachments/tracecmd.py
@@ -7,6 +7,7 @@ from benchkit.shell.shellasync import AsyncProcess
 from benchkit.utils.types import PathType
 from benchkit.platforms import get_current_platform, Platform
 import pathlib
+import time
 
 
 class TraceCmd:
@@ -54,13 +55,13 @@ class TraceCmd:
         print(rdd)
 
         self._process.wait()
-
+        
         command = ["trace-cmd", "report", "trace.dat"]
-            
-        AsyncProcess(
-            platform=self._platform,
-            arguments=command,
-            stdout_path=rdd / "generate-graph.out",
-            stderr_path=rdd / "generate-graph.err",
+                
+        output = self._platform.comm.shell(
+            command=command,
             current_dir=rdd,
+            print_output=False
         )
+        write_record_file_fun(output, "generate-graph.out")
+        

--- a/benchkit/commandattachments/tracecmd.py
+++ b/benchkit/commandattachments/tracecmd.py
@@ -32,7 +32,7 @@ class TraceCmd:
             command.extend(["-e", event])
 
         # Add the PID and output file arguments
-        command.extend(["-P", f"{pid}", "-o", f"{out_file}"])
+        command.extend(["-P", f"{self.pid}", "-o", f"{out_file}"])
 
         AsyncProcess(
             platform=self.platform,

--- a/benchkit/commandattachments/tracecmd.py
+++ b/benchkit/commandattachments/tracecmd.py
@@ -13,6 +13,7 @@ class TraceCmd:
     def __init__(self, events: List[str] = (), platform: Platform = None,) -> None:
         self.events = [str(e) for e in events]
         self.platform = platform if platform is not None else get_current_platform()
+        self.pid = None
         
     def attachement(
         self,
@@ -23,7 +24,7 @@ class TraceCmd:
         rdd = pathlib.Path(record_data_dir)
         out_file = rdd / "trace.dat"
 
-        pid = process.pid
+        self.pid = process.pid
         command = ["sudo", "trace-cmd", "record"]
 
         # Add "-e" and each event to the command list
@@ -40,3 +41,23 @@ class TraceCmd:
             stderr_path=rdd / "trace-cmd.err",
             current_dir=rdd,
         )
+
+    def post_run_hook(
+        self,
+        record_data_dir: PathType,
+        **kwargs
+        ) -> None:
+        
+        rdd = pathlib.Path(record_data_dir)
+        print(rdd)
+        
+        command = ["trace-cmd", "report", "trace.dat"]
+            
+        AsyncProcess(
+            platform=self.platform,
+            arguments=command,
+            stdout_path=rdd / "generate-graph.out",
+            stderr_path=rdd / "generate-graph.err",
+            current_dir=rdd,
+        )
+        

--- a/tests/campaigns/campaign_tracecmd.py
+++ b/tests/campaigns/campaign_tracecmd.py
@@ -4,8 +4,6 @@
 
 from benchmarks.cprogram import CProgramBench
 from benchkit.campaign import CampaignIterateVariables
-from benchkit.shell.shellasync import AsyncProcess
-from benchkit.utils.types import PathType
 from benchkit.platforms import get_current_platform
 from benchkit.commandattachments.tracecmd import TraceCmd
 
@@ -17,7 +15,7 @@ def main() -> None:
     CampaignIterateVariables(
         name="attach",
         benchmark=CProgramBench(
-            command_attachments=[traceCmd.attachement],
+            command_attachments=[traceCmd.attachment],
             post_run_hooks=[traceCmd.post_run_hook]
         ),
         nb_runs=1,

--- a/tests/campaigns/campaign_tracecmd.py
+++ b/tests/campaigns/campaign_tracecmd.py
@@ -13,10 +13,12 @@ from benchkit.commandattachments.tracecmd import TraceCmd
 def main() -> None:
     platform = get_current_platform()
 
+    traceCmd = TraceCmd(["sched"], platform)
     CampaignIterateVariables(
         name="attach",
         benchmark=CProgramBench(
-            command_attachments=[TraceCmd(["sched"], platform).attachement],
+            command_attachments=[traceCmd.attachement],
+            post_run_hooks=[traceCmd.post_run_hook]
         ),
         nb_runs=1,
         variables=[{}],


### PR DESCRIPTION
This PR fixes the fact that the post_run_hook was an AsyncProcess. It is now possible to do post-dataprocessing on the output without race conditions. The process will now also not interfere with the experiment. 