### PR TITLE
prerunhooks: add the access to "other variables"

### DIFF
--- a/benchkit/benchmark.py
+++ b/benchkit/benchmark.py
@@ -61,6 +61,7 @@ class PreRunHook(Protocol):
         self,
         build_variables: RecordResult,
         run_variables: RecordResult,
+        other_variables: RecordResult,
         record_data_dir: PathType,
     ) -> None: ...
 
@@ -1034,6 +1035,7 @@ class Benchmark:
                 pre_run_hook(
                     build_variables=build_variables,
                     run_variables=run_variables,
+                    other_variables=other_variables,
                     record_data_dir=temp_record_data_dir,
                 )
 

--- a/examples/tilt/kit/tiltlib.py
+++ b/examples/tilt/kit/tiltlib.py
@@ -5,7 +5,7 @@ import pathlib
 import sys
 from typing import Any, Dict, Iterable, List, Tuple
 
-from benchkit.benchmark import Benchmark, SharedLib
+from benchkit.benchmark import Benchmark, SharedLib, CommandWrapper, CommandAttachment, PreRunHook, PostRunHook
 from benchkit.platforms import Platform
 from benchkit.sharedlibs import FromSourceSharedLib
 from benchkit.utils.dir import caller_dir
@@ -83,15 +83,19 @@ class SimpleMutexTestBench(Benchmark):
     def __init__(
         self,
         src_dir: PathType = "",
-        shared_libs: Iterable[SharedLib] = (),
+        command_wrappers: Iterable[CommandWrapper] = (),
+        command_attachments: Iterable[CommandAttachment] = (),
+        shared_libs: Iterable[SharedLib] =(),
+        pre_run_hooks: Iterable[PreRunHook] = (),
+        post_run_hooks: Iterable[PostRunHook] = (),
         platform: Platform = None,
     ) -> None:
         super().__init__(
-            command_wrappers=(),
-            command_attachments=(),
+            command_wrappers=command_wrappers,
+            command_attachments=command_attachments,
             shared_libs=shared_libs,
-            pre_run_hooks=(),
-            post_run_hooks=(),
+            pre_run_hooks=pre_run_hooks,
+            post_run_hooks=post_run_hooks,
         )
         if platform is not None:
             self.platform = platform

--- a/examples/tilt/kit/tiltlib.py
+++ b/examples/tilt/kit/tiltlib.py
@@ -5,7 +5,14 @@ import pathlib
 import sys
 from typing import Any, Dict, Iterable, List, Tuple
 
-from benchkit.benchmark import Benchmark, SharedLib, CommandWrapper, CommandAttachment, PreRunHook, PostRunHook
+from benchkit.benchmark import (
+    Benchmark,
+    CommandAttachment,
+    CommandWrapper,
+    PostRunHook,
+    PreRunHook,
+    SharedLib,
+)
 from benchkit.platforms import Platform
 from benchkit.sharedlibs import FromSourceSharedLib
 from benchkit.utils.dir import caller_dir
@@ -85,7 +92,7 @@ class SimpleMutexTestBench(Benchmark):
         src_dir: PathType = "",
         command_wrappers: Iterable[CommandWrapper] = (),
         command_attachments: Iterable[CommandAttachment] = (),
-        shared_libs: Iterable[SharedLib] =(),
+        shared_libs: Iterable[SharedLib] = (),
         pre_run_hooks: Iterable[PreRunHook] = (),
         post_run_hooks: Iterable[PostRunHook] = (),
         platform: Platform = None,


### PR DESCRIPTION
This is a breaking changes in the API of PreRunHook's: we add a variable to the call back to get access to the variables that neither "build variables" or "run variables".