### PR TITLE
fix: Minimal support for Darwin

### DIFF
--- a/benchkit/utils/system.py
+++ b/benchkit/utils/system.py
@@ -22,6 +22,8 @@ def _get_windows_boot_args() -> str:
 def _get_netbsd_boot_args() -> str:
     return "<boot args fetching is unsupported on NetBSD>"
 
+def _get_darwin_boot_args() -> str:
+    return "<boot args fetching is unsupported on Darwin>"
 
 def get_boot_args() -> str:
     """
@@ -40,6 +42,8 @@ def get_boot_args() -> str:
             result = _get_windows_boot_args()
         case "NetBSD":
             result = _get_netbsd_boot_args()
+        case "Darwin":
+            result = _get_darwin_boot_args()
         case other:
             raise ValueError(f"Unsupported operating system: {other}")
     return result


### PR DESCRIPTION
To run benchkit on macOS a mock function to return a constant boot string has to be implemented. 