### PR TITLE
Introduce CLI interface

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -218,3 +218,6 @@ Better document the following:
 - deep numa hierarchy
 
 - remote benchmarking
+
+Consider Canonical documentation mindset:
+https://ubuntu.com/blog/diataxis-a-new-foundation-for-canonical-documentation

--- a/benchkit/cli/__init__.py
+++ b/benchkit/cli/__init__.py
@@ -1,0 +1,130 @@
+# Copyright (C) 2025 Vrije Universiteit Brussel. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Benchkit CLI.
+
+Usage:
+  benchkit install [--editable | --repo=<repo_path>]
+  benchkit activate
+  benchkit init \
+    [--module=<mod> | --command=<cmd> | --run-command=<rcmd> [--build-command=<bcmd>] ] \
+    [--single-file | --full] [--git] [--current-dir=<dir>] [--nb-runs=<n>]
+  benchkit run [--campaign-file=<file>]
+  benchkit module list
+  benchkit module run --module=<mod>
+  benchkit module init --module=<mod>
+  benchkit (-h | --help)
+  benchkit --version
+
+Options:
+  -h --help                   Show this help message.
+  --version                   Show version.
+  --command=<cmd>             Command to execute.
+  --build-command=<bcmd>      Command to build before running.
+  --run-command=<rcmd>        Command to run after building.
+  --current-dir=<dir>         Directory to run the command in [default: .].
+  --nb-runs=<n>               Number of times to execute the command [default: 5].
+  --single-file               Create a minimal single-file setup [default: True].
+  --full                      Create a full benchmark structure [default: False].
+  --module=<mod>              Specify a module [default: none].
+
+Examples:
+  benchkit init --command="echo myresult" --nb-runs=3
+  benchkit init --single-file
+  benchkit init --full
+  benchkit run --command="echo myresult" --nb-runs=3
+  benchkit run --build-command="gcc -o test test.c" --run-command="./test" --nb-runs=5
+  benchkit module list
+  benchkit module run --module="leveldb"
+"""
+
+
+from docopt import docopt
+
+
+def list_modules():
+    """List available benchmark modules."""
+    modules = ["leveldb", "kyotocabinet"]
+    print("Available modules:", ", ".join(modules))
+
+
+def run_module(args):
+    """Run a predefined module."""
+    print(f"Running module: {args['--module']}")
+
+
+def init_module(args):
+    """Initialize a new module."""
+    print(f"Initializing module: {args['--module']}")
+
+
+def main() -> None:
+    args = docopt(__doc__)
+
+    use_module: bool = args["module"]
+    module: str = args["--module"]
+    command: str = args["--command"]
+    run_command: str = args["--run-command"]
+    build_command: str = args["--build-command"]
+    current_dir: str = args["--current-dir"]
+    nb_runs: int = int(args["--nb-runs"]) if args["--nb-runs"] else 3
+    campaign_file: str = args["--campaign-file"]
+
+    run_command = command or run_command or "echo 'Replace this command'"
+    build_command = build_command or ""
+    current_dir = current_dir
+    nb_runs = nb_runs
+
+    if args["install"]:
+        from benchkit.cli.binstall import benchkit_install
+
+        if args["--editable"]:
+            benchkit_install(editable=True)
+        elif "--repo" in args:
+            benchkit_install(editable=True, benchkit_repo_path=args["--repo"])
+        else:
+            benchkit_install(editable=False)
+        return
+
+    if args["activate"]:
+        from benchkit.cli.binstall import benchkit_activate
+
+        benchkit_activate()
+
+    if args["init"]:
+        from benchkit.cli.init import benchkit_init
+
+        split_benchmark_campaign = False
+        if args["--single-file"]:
+            split_benchmark_campaign = False
+        if args["--full"]:
+            split_benchmark_campaign = True
+
+        git = False
+        if args["--git"]:
+            git = True
+
+        benchkit_init(
+            build_command=build_command,
+            run_command=run_command,
+            nb_runs=nb_runs,
+            command_dir=current_dir,
+            campaign_filename="",
+            git=git,
+            split_benchmark_campaign=split_benchmark_campaign,
+        )
+        return
+
+    if args["run"]:
+        from benchkit.cli.run import benchkit_run
+
+        benchkit_run(campaign_file=campaign_file)
+
+    if args["module"]:
+        print(use_module)
+        print(module)
+        raise NotImplementedError("Will come in the future.")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchkit/cli/binstall.py
+++ b/benchkit/cli/binstall.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2025 Vrije Universiteit Brussel. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import os
+import subprocess
+from pathlib import Path
+
+from benchkit.cli.findvenv import find_global_venv
+
+_BENCHKIT_INSTALL_PATH = Path("~/.benchkit").expanduser().resolve()
+COLOR_START = "\033[95m"
+COLOR_END = "\033[0m"
+
+
+def _detect_parent_shell() -> str:
+    # Get the command name of the parent process
+    output = subprocess.check_output(
+        ["ps", "-p", str(os.getppid()), "-o", "comm="],
+        text=True,
+    ).strip()
+    return Path(output).name
+
+
+def _add_symlinks(venv_path: Path) -> None:
+    """Create symlinks in ~/.benchkit for all activate scripts."""
+    venv_bin = venv_path / "bin"
+    target_dir = _BENCHKIT_INSTALL_PATH
+
+    for activate_file in venv_bin.glob("activate*"):
+        link_name = target_dir / activate_file.name
+        try:
+            if link_name.is_symlink() or link_name.exists():
+                link_name.unlink()
+            link_name.symlink_to(activate_file)
+            print(f"Linked: {link_name} -> {activate_file}")
+        except Exception as e:
+            print(f"Failed to link {link_name}: {e}")
+
+
+def benchkit_install(
+    editable: bool = False,
+    benchkit_repo_path: str = "",
+) -> None:
+    if editable and not benchkit_repo_path:
+        benchkit_parent_path = _BENCHKIT_INSTALL_PATH
+        benchkit_parent_path.mkdir(parents=True, exist_ok=True)
+        benchkit_repo_path_hidden = benchkit_parent_path / "benchkit"
+        if not benchkit_repo_path_hidden.is_dir():
+            subprocess.check_call(
+                args=["git", "clone", "https://github.com/open-s4c/benchkit.git"],
+                cwd=benchkit_parent_path,
+            )
+        benchkit_repo_path = str(benchkit_repo_path_hidden)
+
+    venv_path = find_global_venv(benchkit_repo_path=benchkit_repo_path)
+    _add_symlinks(venv_path=venv_path)
+    print(f"{COLOR_START}-- benchkit installed.{COLOR_END}")
+    benchkit_activate()
+
+
+def benchkit_activate() -> None:
+    shell = _detect_parent_shell()
+
+    suffix = ""
+    if "fish" in shell:
+        suffix = ".fish"
+    elif "csh" in shell or "tcsh" in shell:
+        suffix = ".csh"
+    # Default for bash, zsh, etc. is ""
+
+    activate_path = f"~/.benchkit/activate{suffix}"
+
+    print(f"{COLOR_START}-- Activate by running this:\n. {activate_path}{COLOR_END}")
+
+
+if __name__ == "__main__":
+    benchkit_install(
+        editable=True,
+        benchkit_repo_path="~/git/vub/benchkit",
+    )

--- a/benchkit/cli/findvenv.py
+++ b/benchkit/cli/findvenv.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2025 Vrije Universiteit Brussel. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+
+def create_venv(
+    venv_dir: Path,
+) -> None:
+    venv_parent = str(venv_dir.parent)
+    venv_stem = venv_dir.stem
+
+    subprocess.check_output(
+        ["/usr/bin/python3", "-m", "venv", f"{venv_stem}"],
+        cwd=venv_parent,
+        env={},
+    )
+
+
+def install_pkgs_in_venv(
+    full: bool,
+    latest_deps: bool,
+    venv_dir: Path,
+    benchkit_repo_path: str,
+) -> None:
+    pip3 = (venv_dir / "bin/pip3").resolve()
+
+    def install_pip_pkg(packages: List[str]) -> None:
+        for pkg in packages:
+            print(f"Installing package in venv '{venv_dir}': {pkg}", file=sys.stderr)
+        subprocess.check_call([f"{pip3}", "install", "--upgrade"] + packages)
+
+    if full:
+        install_pip_pkg(packages=["pip"])
+        install_pip_pkg(packages=["setuptools"])
+        install_pip_pkg(packages=["wheel"])
+
+    if benchkit_repo_path:
+        subprocess.check_call([f"{pip3}", "install", "--editable", f"{benchkit_repo_path}"])
+    else:
+        install_pip_pkg(packages=["pybenchkit"])
+
+    if full:
+        packages = [
+            "black<=24.10.0",
+            "black[d]<=24.10.0",
+            "black[jupyter]<=24.10.0",
+            "docopt<=0.6.2",
+            "flake8<=7.1.1",
+            "isort<=5.13.2",
+            "libtmux<=0.40.0",
+            "pycodestyle<=2.12.1",
+            "pylint<=3.3.2",
+        ]
+        if latest_deps:
+            packages = [p.split("<=")[0].strip() for p in packages]
+        install_pip_pkg(packages=packages)
+
+
+def find_venv(
+    full: bool = True,
+    latest_deps: bool = True,
+    expected_path: str = "",
+    benchkit_repo_path: str = "",
+) -> Path:
+    venv_str = expected_path or ".venv"
+    venv_dir = Path(venv_str).resolve()
+
+    python3 = (venv_dir / "bin/python3").resolve()
+
+    if not all([venv_dir.is_dir(), python3.is_file()]):
+        print("Warning: venv not found, creating one.", file=sys.stderr)
+        create_venv(venv_dir=venv_dir)
+        install_pkgs_in_venv(
+            full=full,
+            latest_deps=latest_deps,
+            venv_dir=venv_dir,
+            benchkit_repo_path=benchkit_repo_path,
+        )
+
+    return venv_dir
+
+
+def find_global_venv(
+    benchkit_repo_path: str = "",
+) -> Path:
+    if benchkit_repo_path:
+        benchkit_repo_path = str(Path(benchkit_repo_path).expanduser().resolve())
+    else:
+        benchkit_repo_path = ""
+
+    benchkit_global_path = Path("~/.benchkit").expanduser().resolve()
+    benchkit_global_path.mkdir(parents=True, exist_ok=True)
+    venv_path = benchkit_global_path / ".venv"
+    return find_venv(
+        full=True,
+        latest_deps=False,
+        expected_path=str(venv_path),
+        benchkit_repo_path=benchkit_repo_path,
+    )

--- a/benchkit/cli/generate.py
+++ b/benchkit/cli/generate.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2025 Vrije Universiteit Brussel. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import shlex
+
+from benchkit.utils.dir import caller_dir
+
+_TEMPLATES_DIR = (caller_dir() / "templates").resolve()
+_BENCHMARK_BODY_TEMPLATE_PATH = (_TEMPLATES_DIR / "benchmark_body").resolve()
+_BENCHMARK_HEADER_TEMPLATE_PATH = (_TEMPLATES_DIR / "benchmark_header").resolve()
+_CAMPAIGN_BODY_TEMPLATE_PATH = (_TEMPLATES_DIR / "campaign_body").resolve()
+_CAMPAIGN_HEADER_TEMPLATE_PATH = (_TEMPLATES_DIR / "campaign_header").resolve()
+_GITIGNORE_TEMPLATE_PATH = (_TEMPLATES_DIR / "gitignore").resolve()
+
+
+assert _TEMPLATES_DIR.is_dir()
+assert _BENCHMARK_BODY_TEMPLATE_PATH.is_file()
+assert _BENCHMARK_HEADER_TEMPLATE_PATH.is_file()
+assert _CAMPAIGN_BODY_TEMPLATE_PATH.is_file()
+assert _CAMPAIGN_HEADER_TEMPLATE_PATH.is_file()
+assert _GITIGNORE_TEMPLATE_PATH.is_file()
+
+
+def generate_benchmark(
+    build_command: str,
+    run_command: str,
+    command_dir: str,
+    header: bool,
+) -> str:
+    build_command_list = shlex.split(build_command) if build_command else []
+    run_command_list = shlex.split(run_command) if run_command else ["echo", "PUT-COMMAND-HERE"]
+    command_dir_str = str(command_dir) or "."
+
+    template = _BENCHMARK_BODY_TEMPLATE_PATH.read_text()
+    benchmark_content = template.format(
+        build_command=build_command_list,
+        run_command=run_command_list,
+        command_dir=command_dir_str,
+    )
+
+    if header:
+        benchmark_header = _BENCHMARK_HEADER_TEMPLATE_PATH.read_text().strip()
+        benchmark_content = benchmark_header + "\n\n" + benchmark_content
+
+    return benchmark_content.strip()
+
+
+def generate_campaign(
+    benchmark_content: str,
+    nb_runs: int,
+) -> str:
+    benchmark_content = benchmark_content or _CAMPAIGN_HEADER_TEMPLATE_PATH.read_text()
+    template = _CAMPAIGN_BODY_TEMPLATE_PATH.read_text()
+    campaign_content = template.format(
+        benchmark_content=benchmark_content,
+        nb_runs=nb_runs,
+    )
+
+    return campaign_content.strip()
+
+
+def get_gitignore_content() -> str:
+    return _GITIGNORE_TEMPLATE_PATH.read_text().strip() + "\n"

--- a/benchkit/cli/init.py
+++ b/benchkit/cli/init.py
@@ -1,0 +1,135 @@
+# Copyright (C) 2025 Vrije Universiteit Brussel. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import subprocess
+from pathlib import Path
+
+import black
+import isort
+
+from benchkit.cli.generate import (
+    generate_benchmark,
+    generate_campaign,
+    get_gitignore_content,
+)
+
+_DOTGIT_DIR = Path(".git")
+_GITIGNORE_PATH = Path(".gitignore")
+_VENV_PATH = Path(".venv")
+_CAMPAIGNS_DIR = Path("campaigns")
+_BENCHMARKS_DIR = _CAMPAIGNS_DIR / "benchmarks"
+
+
+def create_git() -> None:
+    if _DOTGIT_DIR.is_dir():
+        return
+    subprocess.run(["git", "init"])
+
+
+def gitignore() -> None:
+    _GITIGNORE_PATH.write_text(get_gitignore_content())
+
+
+def git_add() -> None:
+    subprocess.run(["git", "add", "."])
+
+
+def git_status() -> None:
+    subprocess.run(["git", "status"])
+
+
+def format_py_src(src_content: str) -> str:
+    black_mode = black.Mode(line_length=100)  # TODO apply toml config file
+    src_content_isort = isort.code(code=src_content)
+    src_content_black = black.format_str(src_contents=src_content_isort, mode=black_mode)
+    src_content_result = src_content_black.strip()
+    return src_content_result
+
+
+def benchkit_init(
+    build_command: str,
+    run_command: str,
+    nb_runs: int,
+    command_dir: str,
+    campaign_filename: str,
+    git: bool,
+    split_benchmark_campaign: bool,
+) -> None:
+    campaign_filename = campaign_filename or "campaign.py"
+
+    benchmark_content = generate_benchmark(
+        build_command=build_command,
+        run_command=run_command,
+        command_dir=command_dir,
+        header=split_benchmark_campaign,
+    )
+    campaign_content = generate_campaign(
+        benchmark_content="" if split_benchmark_campaign else benchmark_content,
+        nb_runs=nb_runs,
+    )
+
+    if git:
+        create_git()
+        gitignore()
+
+    if split_benchmark_campaign:
+        campaign_content = format_py_src(campaign_content)
+        benchmark_content = format_py_src(benchmark_content)
+        _CAMPAIGNS_DIR.mkdir(parents=True, exist_ok=True)
+        _BENCHMARKS_DIR.mkdir(parents=True, exist_ok=True)
+        campaign_pathname = (_CAMPAIGNS_DIR / campaign_filename).resolve()
+        benchmark_pathname = (_BENCHMARKS_DIR / "__init__.py").resolve()
+
+        if campaign_pathname.is_file():
+            print(f"❌ {campaign_pathname} already exists. Aborting.")
+            exit(1)
+
+        if benchmark_pathname.is_file():
+            print(f"❌ {benchmark_pathname} already exists. Aborting.")
+            exit(1)
+
+        campaign_pathname.write_text(campaign_content)
+        benchmark_pathname.write_text(benchmark_content)
+
+        rel_benchmark = benchmark_pathname.relative_to(Path.cwd())
+        rel_campaign = campaign_pathname.relative_to(Path.cwd())
+        print(
+            (
+                f'✅ Initialized benchmark ("{rel_benchmark}") '
+                f'& campaign ("{rel_campaign}")\n'
+                f'with command: "{run_command}"'
+            )
+        )
+    else:
+        campaign_content = format_py_src(campaign_content)
+        campaign_pathname = Path(campaign_filename).resolve()
+
+        if campaign_pathname.is_file():
+            print(f"❌ {campaign_pathname} already exists. Aborting.")
+            exit(1)
+
+        campaign_pathname.write_text(campaign_content)
+
+        rel_campaign = campaign_pathname.relative_to(Path.cwd())
+        print(
+            (
+                f'✅ Initialized single-file benchmark & campaign: "{rel_campaign}"\n'
+                f'   with command: "{run_command}"'
+            )
+        )
+
+    if git:
+        git_add()
+        git_status()
+
+
+if __name__ == "__main__":
+    benchkit_init(
+        build_command="",
+        run_command="echo throughput=10",
+        nb_runs=4,
+        command_dir="/tmp/c",
+        campaign_filename="testcamp.py",
+        git=False,
+        split_benchmark_campaign=True,
+    )

--- a/benchkit/cli/run.py
+++ b/benchkit/cli/run.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2025 Vrije Universiteit Brussel. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import subprocess
+import sys
+from pathlib import Path
+
+from benchkit.cli.findvenv import find_global_venv
+
+
+def benchkit_run(
+    campaign_file: str,
+) -> None:
+    campaign_path = Path(campaign_file if campaign_file else "campaign.py")
+
+    if not campaign_path.is_file():
+        print(f"Campaign file not found: {campaign_path}", file=sys.stderr)
+        exit(1)
+
+    venv_path = find_global_venv()
+    python3 = venv_path / "bin/python3"
+
+    subprocess.check_call([f"{python3}", f"{campaign_path}"])

--- a/benchkit/cli/templates/benchmark_body
+++ b/benchkit/cli/templates/benchmark_body
@@ -1,0 +1,100 @@
+from pathlib import Path
+from typing import List, Dict, Any
+
+class MyBenchmark(Benchmark):
+    def __init__(
+        self,
+    ) -> None:
+        super().__init__(
+            command_wrappers=(),
+            command_attachments=(),
+            shared_libs=(),
+            pre_run_hooks=(),
+            post_run_hooks=(),
+        )
+
+        # Replace the following by the path where to build/run your benchmark.
+        self._bench_src_path = Path("{command_dir}").resolve()
+
+    @property
+    def bench_src_path(self) -> Path:
+        return self._bench_src_path
+
+    @staticmethod
+    def get_build_var_names() -> List[str]:
+        return [
+            # list here your build variable names as strings
+        ]
+
+    @staticmethod
+    def get_run_var_names() -> List[str]:
+        return [
+            # list here your run variable names as strings
+        ]
+
+    def clean_bench(self) -> None:
+        # Add here the steps to clean the benchmark (optional).
+        pass
+
+    def prebuild_bench(
+        self,
+        **kwargs,
+    ) -> int:
+        # Fill here general build steps that do not depend on the build
+        # variables. Return the time it took, in seconds.
+        return 0
+
+    def build_bench(
+        self,
+        # add here build variables for your benchmark
+        **kwargs,
+    ) -> None:
+        # Replace the following command by the steps to build your benchmark.
+        build_command = {build_command}
+
+        if not build_command:
+            return
+
+        self.platform.comm.shell(
+            command=build_command,
+            current_dir=self.bench_src_path,
+        )
+
+    def single_run(
+        self,
+        # Add here run variables for your benchmark.
+        **kwargs,
+    ) -> str:
+        current_dir = self.bench_src_path
+        environment = self._preload_env(**kwargs)
+
+        # Replace the following command by the steps to run your benchmark.
+        run_command = {run_command}
+
+        wrapped_run_command, wrapped_environment = self._wrap_command(
+            run_command=run_command,
+            environment=environment,
+            **kwargs,
+        )
+
+        output = self.run_bench_command(
+            run_command=run_command,
+            wrapped_run_command=wrapped_run_command,
+            current_dir=current_dir,
+            environment=environment,
+            wrapped_environment=wrapped_environment,
+            print_output=True,
+        )
+
+        return output
+
+    def parse_output_to_results(self, command_output: str, **_kwargs,) -> Dict[str, Any]:
+        # Assume last line contains a single number as output:
+        output = command_output.strip().splitlines()[-1].strip()
+
+        result_dict = {{
+            "result": output,
+            # Add here other output variables.
+        }}
+
+        return result_dict

--- a/benchkit/cli/templates/benchmark_header
+++ b/benchkit/cli/templates/benchmark_header
@@ -1,0 +1,1 @@
+from benchkit.benchmark import Benchmark

--- a/benchkit/cli/templates/campaign_body
+++ b/benchkit/cli/templates/campaign_body
@@ -1,0 +1,28 @@
+from benchkit.benchmark import Benchmark
+from benchkit.campaign import CampaignCartesianProduct, CampaignSuite
+
+{benchmark_content}
+
+def main() -> None:
+    benchmark = MyBenchmark()
+
+    campaign = CampaignCartesianProduct(
+        name="benchmark",
+        benchmark=benchmark,
+        nb_runs={nb_runs},
+        variables={{}},
+        constants=None,
+        debug=False,
+        gdb=False,
+        enable_data_dir=True,
+        continuing=False,
+        benchmark_duration_seconds=None,
+    )
+
+    campaign_suite = CampaignSuite(campaigns=[campaign])
+    campaign_suite.print_durations()
+    campaign_suite.run_suite()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchkit/cli/templates/campaign_header
+++ b/benchkit/cli/templates/campaign_header
@@ -1,0 +1,1 @@
+from benchmarks import MyBenchmark

--- a/benchkit/cli/templates/gitignore
+++ b/benchkit/cli/templates/gitignore
@@ -1,0 +1,3 @@
+.venv/
+venv/
+.idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,16 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
+dependencies = [
+  "docopt<=0.6.2",
+]
 
 [project.urls]
 Homepage = "https://github.com/open-s4c/benchkit"
 Issues = "https://github.com/open-s4c/benchkit/issues"
+
+[project.scripts]
+benchkit = "benchkit.cli:main"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
To improve the "first impression" of benchkit, we introduce a CLI interface that helps bootstrap benchmarking projects. The CLI provides:

- Benchmark template generation with multiple layout options
- Installation of the benchkit virtual environment and repository under ~/.benchkit
- Activation helpers and shell-aware suggestions for environment setup

Eventually, this enables a streamlined install process requiring only:

  pip3 install --user pybenchkit
  ~/.local/bin/benchkit install
  . ~/.benchkit/activate

With that, the host machine is ready to run benchmarks. Benchmark skeletons can then be generated and run as follows:

  benchkit init --command="echo bench" --single-file --git
  benchkit run

All that's left is to profit from the benchmark results.