### PR TITLE
refactor(benchmark): Return default value from `get_tilt_var_names`

### DIFF
--- a/benchkit/benchmark.py
+++ b/benchkit/benchmark.py
@@ -178,7 +178,7 @@ class Benchmark:
         Returns:
             List[str]: the names of the tilt variables.
         """
-        raise NotImplementedError
+        return []
 
     @staticmethod
     def _write_to_record_data_dir(


### PR DESCRIPTION
Using `tilt` is deprecated, so the `get_tilt_var_names` function should not longer be used, but since, every time it was called, this function returned a `notImplementedError`, this function still had to be overwritten every time you wanted to create a new benchmark class. Returning an empty list by default fixes this.