### PR TITLE
added .DS_Store to . gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ venv/
 .venv/
 .idea/
 .vscode/
+.DS_Store
 results/
 benchkit.egg-info/


### PR DESCRIPTION
Added .[DS_Store](https://en.wikipedia.org/wiki/.DS_Store) to .gitignore to prevent macOS-specific metadata files from being tracked in the repository.