### PR TITLE
Add Nsight profiling support (nsys/ncu)

### DIFF
--- a/benchkit/communication/__init__.py
+++ b/benchkit/communication/__init__.py
@@ -328,6 +328,27 @@ class CommunicationLayer:
         """
         raise NotImplementedError
 
+    def host_to_comm_path(self, host_path: pathlib.Path) -> pathlib.Path:
+        """
+        Convert a path from the host namespace to the namespace visible to the communication
+        platform (e.g., container, remote host).
+
+        This function is used to adapt paths that Benchkit generates (e.g., to save results)
+        into equivalent paths visible inside the platform that actually runs the benchmark.
+
+        Default behavior assumes a shared filesystem and returns the original path.
+
+        Override in platform-specific subclasses if path rewriting is required
+        (e.g., Docker volume mounts or remote mount points).
+
+        Args:
+            host_path (Path): Absolute path on the host machine.
+
+        Returns:
+            Path: Corresponding path visible to the communication platform.
+        """
+        return host_path
+
     def copy_from_host(self, source: PathType, destination: PathType) -> None:
         """Copy a file from the host (the machine benchkit is run on), to the
            target machine the benchmark will be performed on.

--- a/examples/gpus/campaign_gpus.py
+++ b/examples/gpus/campaign_gpus.py
@@ -2,119 +2,26 @@
 # Copyright (C) 2024 Vrije Universiteit Brussel. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import pathlib
-from typing import Any, Dict, List
 
+from addvec import AddVecBench
 from gpus import get_gpu_docker_platform
 
-from benchkit.benchmark import Benchmark
 from benchkit.campaign import CampaignCartesianProduct, CampaignSuite
-from benchkit.platforms import Platform
 from benchkit.utils.dir import caller_dir
-from benchkit.utils.types import PathType
-
-GUEST_SRC_DIR = "/home/user/src"
 
 
-class AddVecBench(Benchmark):
-    def __init__(
-        self,
-        platform: Platform,
-        src_dir: PathType,
-    ) -> None:
-        super().__init__(
-            command_wrappers=(),
-            command_attachments=(),
-            shared_libs=(),
-            pre_run_hooks=(),
-            post_run_hooks=(),
-        )
-        self.platform = platform
-        self._bench_src_path = pathlib.Path(src_dir)
-
-    @property
-    def bench_src_path(self) -> pathlib.Path:
-        return self._bench_src_path
-
-    @staticmethod
-    def get_build_var_names() -> List[str]:
-        return ["block_size"]
-
-    @staticmethod
-    def get_run_var_names() -> List[str]:
-        return []
-
-    def build_bench(
-        self,
-        block_size: int,
-        **kwargs,
-    ) -> None:
-        self.platform.comm.shell(
-            command=f"nvcc add.cu -DBLOCK_SIZE={block_size} -o add_cuda",
-            current_dir=f"{self._bench_src_path}",
-            output_is_log=True,
-        )
-
-    def single_run(
-        self,
-        **kwargs,
-    ) -> str:
-        current_dir = self.bench_src_path
-        environment = self._preload_env(**kwargs)
-
-        run_command = ["./add_cuda"]
-        wrapped_run_command, wrapped_environment = self._wrap_command(
-            run_command=run_command,
-            environment=environment,
-            **kwargs,
-        )
-
-        output = self.run_bench_command(
-            run_command=run_command,
-            wrapped_run_command=wrapped_run_command,
-            current_dir=current_dir,
-            environment=environment,
-            wrapped_environment=wrapped_environment,
-            print_output=True,
-        )
-        return output
-
-    def parse_output_to_results(
-        self,
-        command_output: str,
-        **_kwargs,
-    ) -> Dict[str, Any]:
-        result_dict = {}
-
-        i = command_output.index("Outputs:")
-        lines = command_output[i:].splitlines()
-        for line in lines[1:]:
-            if ":" in line:
-                print(line)
-                left, right = line.rsplit(":")
-                result_dict[left.strip()] = right.strip()
-
-        return result_dict
-
-
-def get_docker_platform() -> Platform:
-    host_src_dir = (caller_dir() / "src").resolve()
+def main() -> None:
+    nb_runs = 3
+    guest_src_dir = "/home/user/project"
 
     platform = get_gpu_docker_platform(
-        host_src_dir=host_src_dir,
-        guest_src_dir=GUEST_SRC_DIR,
+        host_src_dir=(caller_dir() / "src").resolve(),
+        guest_src_dir=guest_src_dir,
     )
-
-    return platform
-
-
-def main():
-    nb_runs = 3
-    platform = get_docker_platform()
 
     bench = AddVecBench(
         platform=platform,
-        src_dir=GUEST_SRC_DIR,
+        src_dir=guest_src_dir,
     )
 
     campaign = CampaignCartesianProduct(

--- a/examples/gpus/campaign_nsys_ncu.py
+++ b/examples/gpus/campaign_nsys_ncu.py
@@ -9,11 +9,11 @@ from typing import List
 from addvec import AddVecBench
 from gpus import get_gpu_docker_platform
 from nsightwrappers import NcuWrap, NsysWrap
-from platforms import Platform
 
 from benchkit.benchmark import PostRunHook
 from benchkit.campaign import CampaignCartesianProduct, CampaignSuite
 from benchkit.commandwrappers import CommandWrapper
+from benchkit.platforms import Platform
 from benchkit.utils.dir import caller_dir
 
 nb_runs = 1

--- a/examples/gpus/campaign_nsys_ncu.py
+++ b/examples/gpus/campaign_nsys_ncu.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright (C) 2024 Vrije Universiteit Brussel. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+
+from pathlib import Path
+from typing import List
+
+from addvec import AddVecBench
+from gpus import get_gpu_docker_platform
+from nsightwrappers import NcuWrap, NsysWrap
+from platforms import Platform
+
+from benchkit.benchmark import PostRunHook
+from benchkit.campaign import CampaignCartesianProduct, CampaignSuite
+from benchkit.commandwrappers import CommandWrapper
+from benchkit.utils.dir import caller_dir
+
+nb_runs = 1
+guest_project_dir = Path("/home/user/project")
+
+
+def get_campaign(
+    platform: Platform,
+    wrappers: List[CommandWrapper],
+    post_run_hooks: List[PostRunHook],
+) -> CampaignCartesianProduct:
+    campaign = CampaignCartesianProduct(
+        name="gpuaddvec",
+        benchmark=AddVecBench(
+            platform=platform,
+            src_dir=guest_project_dir / "src",
+            command_wrappers=wrappers,
+            post_run_hooks=post_run_hooks,
+        ),
+        nb_runs=nb_runs,
+        variables={
+            "block_size": [256],
+        },
+        constants={},
+        debug=False,
+        gdb=False,
+        enable_data_dir=True,
+        continuing=False,
+        benchmark_duration_seconds=None,
+    )
+
+    return campaign
+
+
+def main() -> None:
+    platform = get_gpu_docker_platform(
+        host_src_dir=caller_dir().resolve(),
+        guest_src_dir=guest_project_dir,
+    )
+
+    nsys_wrap = NsysWrap(platform=platform)
+    ncu_wrap = NcuWrap(platform=platform)
+
+    campaign_nsys = get_campaign(
+        platform=platform,
+        wrappers=[nsys_wrap],
+        post_run_hooks=[nsys_wrap.post_run_hook],
+    )
+
+    campaign_ncu = get_campaign(
+        platform=platform,
+        wrappers=[ncu_wrap],
+        post_run_hooks=[ncu_wrap.post_run_hook],
+    )
+
+    campaign_suite = CampaignSuite(
+        campaigns=[
+            campaign_nsys,
+            campaign_ncu,
+        ]
+    )
+    campaign_suite.run_suite()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/gpus/kit/addvec.py
+++ b/examples/gpus/kit/addvec.py
@@ -1,0 +1,93 @@
+# Copyright (C) 2025 Vrije Universiteit Brussel. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+from benchkit.benchmark import Benchmark, PostRunHook
+from benchkit.commandwrappers import CommandWrapper
+from benchkit.platforms import Platform
+from benchkit.utils.types import PathType
+
+
+class AddVecBench(Benchmark):
+    def __init__(
+        self,
+        platform: Platform,
+        src_dir: PathType,
+        command_wrappers: List[CommandWrapper] = (),
+        post_run_hooks: List[PostRunHook] = (),
+    ) -> None:
+        super().__init__(
+            command_wrappers=command_wrappers,
+            command_attachments=(),
+            shared_libs=(),
+            pre_run_hooks=(),
+            post_run_hooks=post_run_hooks,
+        )
+        self.platform = platform
+        self._bench_src_path = Path(src_dir)
+
+    @property
+    def bench_src_path(self) -> Path:
+        return self._bench_src_path
+
+    @staticmethod
+    def get_build_var_names() -> List[str]:
+        return ["block_size"]
+
+    @staticmethod
+    def get_run_var_names() -> List[str]:
+        return []
+
+    def build_bench(
+        self,
+        block_size: int,
+        **kwargs,
+    ) -> None:
+        self.platform.comm.shell(
+            command=f"nvcc add.cu -DBLOCK_SIZE={block_size} -o add_cuda",
+            current_dir=f"{self._bench_src_path}",
+            output_is_log=True,
+        )
+
+    def single_run(
+        self,
+        **kwargs,
+    ) -> str:
+        current_dir = self.bench_src_path
+        environment = self._preload_env(**kwargs)
+
+        run_command = ["./add_cuda"]
+        wrapped_run_command, wrapped_environment = self._wrap_command(
+            run_command=run_command,
+            environment=environment,
+            **kwargs,
+        )
+
+        output = self.run_bench_command(
+            run_command=run_command,
+            wrapped_run_command=wrapped_run_command,
+            current_dir=current_dir,
+            environment=environment,
+            wrapped_environment=wrapped_environment,
+            print_output=True,
+        )
+        return output
+
+    def parse_output_to_results(
+        self,
+        command_output: str,
+        **_kwargs,
+    ) -> Dict[str, Any]:
+        result_dict = {}
+
+        i = command_output.index("Outputs:")
+        lines = command_output[i:].splitlines()
+        for line in lines[1:]:
+            if ":" in line:
+                print(line)
+                left, right = line.rsplit(":")
+                result_dict[left.strip()] = right.strip()
+
+        return result_dict

--- a/examples/gpus/kit/nsightwrappers.py
+++ b/examples/gpus/kit/nsightwrappers.py
@@ -1,0 +1,177 @@
+# Copyright (C) 2025 Vrije Universiteit Brussel. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import csv
+import re
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from benchkit.benchmark import RecordResult, WriteRecordFileFunction
+from benchkit.commandwrappers import CommandWrapper
+from benchkit.dependencies.packages import PackageDependency
+from benchkit.platforms import Platform
+from benchkit.utils.types import PathType
+
+
+class NsysWrap(CommandWrapper):
+    """Command wrapper for the `nsys` profiling utility."""
+
+    def __init__(
+        self,
+        platform: Platform | None = None,
+        other_options: List[str] = (),
+    ):
+        super().__init__()
+        self.platform = platform
+        self._other_options = [str(o) for o in other_options]
+        self._output_dirname = "nsys_reports"
+        self._trace_filename = "report.nsys-rep"
+
+    def dependencies(self) -> List[PackageDependency]:
+        return super().dependencies() + [PackageDependency("nsys")]
+
+    def command_prefix(
+        self,
+        record_data_dir: Optional[PathType],
+        **kwargs,
+    ) -> List[str]:
+        if record_data_dir is None:
+            raise ValueError("Record data directory is required for nsys output.")
+        output_dir = self._output_dir(record_data_dir=record_data_dir)
+        trace_file = output_dir / self._trace_filename
+
+        cmd_prefix = super().command_prefix(**kwargs)
+
+        options = ["--output", f"{trace_file}"] + self._other_options
+        nsys_prefix = ["nsys", "profile"] + options
+
+        return nsys_prefix + cmd_prefix
+
+    def post_run_hook(
+        self,
+        experiment_results_lines: List[RecordResult],
+        record_data_dir: PathType,
+        write_record_file_fun: WriteRecordFileFunction,
+    ) -> RecordResult:
+        """
+        Post-run hook to extract summary stats from `nsys stats`.
+        """
+        self._run_nsys_stat(record_data_dir=record_data_dir)
+        extracted_stats = self._extract_stats(record_data_dir=record_data_dir)
+        return extracted_stats
+
+    def _output_dir(
+        self,
+        record_data_dir: PathType,
+    ) -> Path:
+        record_data_dir = self.platform.comm.host_to_comm_path(record_data_dir)
+        output_dir = record_data_dir / self._output_dirname
+        self.platform.comm.makedirs(path=output_dir, exist_ok=True)
+        return output_dir
+
+    def _run_nsys_stat(
+        self,
+        record_data_dir: PathType,
+    ) -> None:
+        output_dir = self._output_dir(record_data_dir=record_data_dir)
+        trace_file = output_dir / self._trace_filename
+
+        command = ["nsys", "stats", "--format", "csv", "--output", ".", f"{trace_file}"]
+        self.platform.comm.shell(command=command, output_is_log=True)
+
+    def _extract_stats(
+        self,
+        record_data_dir: PathType,
+    ) -> Dict[str, str]:
+        """Example of statistics that can be extracted from the nsys report."""
+
+        mem_size_path = record_data_dir / self._output_dirname / "report_cuda_gpu_mem_size_sum.csv"
+        extracted = {}
+        with mem_size_path.open(newline="") as csvfile:
+            reader = csv.DictReader(csvfile)
+            for row in reader:
+                operation = row["Operation"]
+                if operation.startswith("["):
+                    operation = operation[1:]
+                if operation.endswith("]"):
+                    operation = operation[:-1]
+
+                extracted[f"nsys/{operation} (MB)"] = row["Total (MB)"]
+
+        return extracted
+
+
+class NcuWrap(CommandWrapper):
+    """Command wrapper for the `ncu` compute profiler utility."""
+
+    def __init__(
+        self,
+        platform: Platform,
+        csv: bool = True,
+        other_options: List[str] = (),
+    ):
+        super().__init__()
+
+        ext = "csv" if csv else "txt"
+
+        self.platform = platform
+        self._csv = csv
+        self._other_options = [str(o) for o in other_options]
+        self._report_filename = f"ncu_general.{ext}"
+
+    def dependencies(self) -> List[PackageDependency]:
+        return super().dependencies() + [PackageDependency("ncu")]
+
+    def command_prefix(
+        self,
+        record_data_dir: Optional[PathType],
+        **kwargs,
+    ) -> List[str]:
+        if record_data_dir is None:
+            raise ValueError("Record data directory is required for ncu output.")
+        record_data_dir = self.platform.comm.host_to_comm_path(record_data_dir)
+        report_path = record_data_dir / self._report_filename
+
+        cmd_prefix = super().command_prefix(**kwargs)
+
+        options = ["--csv", "--log-file", f"{report_path}"] + self._other_options
+        ncu_prefix = ["ncu"] + options
+
+        return ncu_prefix + cmd_prefix
+
+    def post_run_hook(
+        self,
+        experiment_results_lines: List[RecordResult],
+        record_data_dir: PathType,
+        write_record_file_fun: WriteRecordFileFunction,
+    ) -> RecordResult:
+        """
+        Post-run hook to extract summary stats from `ncu stats`.
+        """
+        report_path = record_data_dir / self._report_filename
+        report_txt = report_path.read_text()
+        report_lines = [
+            line.strip() for line in report_txt.splitlines() if not line.startswith("==")
+        ]
+
+        csv_reader = csv.DictReader(report_lines)
+        stats = {}
+        only_numbers_commas_dots = re.compile(r"^[\d,.]+$")
+        for row in csv_reader:
+            keys = ("ID", "Metric Name")
+            unit = row["Metric Unit"]
+            value = row["Metric Value"]
+
+            unit_value = f" ({unit})" if unit else ""
+
+            if not value:
+                continue
+
+            if only_numbers_commas_dots.match(value):
+                value = value.replace(",", "").strip()
+
+            key = "ncu/" + "/".join(row[k] for k in keys) + unit_value
+            stats[key] = value
+            print()
+
+        return stats

--- a/examples/gpus/src/simplesleep.cu
+++ b/examples/gpus/src/simplesleep.cu
@@ -1,0 +1,92 @@
+#include <iostream>
+#include <chrono>
+#include <thread>
+#include <cuda_runtime.h>
+
+// Simple kernel: increments each element
+__global__ void simpleKernel(int *data, int size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < size) {
+        data[idx] += 1;
+    }
+}
+
+// Simple kernel with artificial delay
+__global__ void delayedKernel1(int *data, int size, int delay_iters = 1000000) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < size) {
+        int tmp = data[idx];
+        // Artificial work: spin in a loop
+        for (int i = 0; i < delay_iters; ++i) {
+            tmp += i % 7; // just some computation
+        }
+        data[idx] = tmp;
+    }
+}
+
+// Simple kernel with artificial delay
+__global__ void delayedKernel2(int *data, int size, int delay_iters = 1000000 / 2) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < size) {
+        int tmp = data[idx];
+        // Artificial work: spin in a loop
+        for (int i = 0; i < delay_iters; ++i) {
+            tmp += i % 7; // just some computation
+        }
+        data[idx] = tmp;
+    }
+}
+
+// Helper to print timestamp since start
+auto get_relative_time(std::chrono::steady_clock::time_point start) {
+    auto now = std::chrono::steady_clock::now();
+    auto us = std::chrono::duration_cast<std::chrono::microseconds>(now - start).count();
+    return us / 1000.0; // convert to milliseconds
+}
+
+int main() {
+    const int size = 1 << 20; // 1M elements
+    const int bytes = size * sizeof(int);
+
+    int *h_data = new int[size];
+    for (int i = 0; i < size; i++) {
+        h_data[i] = i;
+    }
+
+    int *d_data;
+    cudaMalloc(&d_data, bytes);
+    cudaMemcpy(d_data, h_data, bytes, cudaMemcpyHostToDevice);
+
+    int threads = 256;
+    int blocks = (size + threads - 1) / threads;
+
+    // Start the timeline
+    auto start_time = std::chrono::steady_clock::now();
+
+    std::cout << "[" << get_relative_time(start_time) << " ms] Launching kernel 1..." << std::endl;
+    delayedKernel1<<<blocks, threads>>>(d_data, size);
+    cudaDeviceSynchronize();
+
+    std::cout << "[" << get_relative_time(start_time) << " ms] Sleeping..." << std::endl;
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    std::cout << "[" << get_relative_time(start_time) << " ms] Launching kernel 2..." << std::endl;
+    delayedKernel2<<<blocks, threads>>>(d_data, size);
+    cudaDeviceSynchronize();
+
+    cudaMemcpy(h_data, d_data, bytes, cudaMemcpyDeviceToHost);
+
+    std::cout << "[" << get_relative_time(start_time) << " ms] Checking results..." << std::endl;
+    std::cout << "Sample results: ";
+    for (int i = 0; i < 5; i++) {
+        std::cout << h_data[i] << " ";
+    }
+    std::cout << "..." << std::endl;
+
+    cudaFree(d_data);
+    delete[] h_data;
+
+    std::cout << "[" << get_relative_time(start_time) << " ms] Done!" << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
- Introduced `host_to_comm_path()` in `CommunicationLayer` and implemented Docker-specific logic in `DockerCommLayer` to resolve host/container path mapping (e.g., for file outputs inside mounted volumes).

- Added new example: `campaign_nsys_ncu.py` showcasing how to run GPU benchmarks with `nsys` and `ncu` wrappers, including post-run hooks for metrics extraction.

- Created `NsysWrap` and `NcuWrap`. `NsysWrap` runs `nsys profile`, then extracts memory usage stats from `report_cuda_gpu_mem_size_sum.csv`. `NcuWrap` runs `ncu` in CSV mode and parses per-kernel metrics from the log.

- Refactored `AddVecBench` into its own reusable file under `examples/gpus/kit/addvec.py`.

- Updated `gpus.py` to install Nsight Systems and libsmctrl by default in the Docker image.

- Added a realistic CUDA benchmark `simplesleep.cu` to simulate kernel workloads with artificial delay and multiple phases.

These changes improve support for automated GPU profiling and set the foundation for deeper performance analysis using NVIDIA's Nsight tooling inside Docker-based benchkit platforms.