### PR TITLE
build: Exclude venv dirs from sdist/wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,24 @@ benchkit = "benchkit.cli:main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build]
+exclude = [
+  "/.venv*",
+  "/venv*",
+  "/env*",
+  "/__pycache__",
+  "*.pyc",
+  "/.git",
+  "/.github",
+]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.venv*",
+  "/venv*",
+  "/env*",
+]
+
 [tool.hatch.build.targets.wheel]
 include = [
   "benchkit/",
@@ -38,8 +56,9 @@ include = [
   "tutorials/",
 ]
 exclude = [
-  "venv*/",
-  ".venv*/",
+  "/.venv*",
+  "/venv*",
+  "/env*",
 ]
 
 [tool.black]


### PR DESCRIPTION
The previous configuration only excluded venv directories via the wheel target's exclude list. Since hatchling's sdist target defaults to including everything not in .gitignore, a `.venv-release/` created in the project root during the release procedure leaked into the tarball.

Mirror pythainer's fix:
- add a top-level [tool.hatch.build] exclude for venv/env/cache/git dirs that both targets inherit;
- add an explicit [tool.hatch.build.targets.sdist] exclude block (the actual fix);
- harmonize the wheel exclude patterns to use root-anchored globs.