### PR TITLE
benches/graph500: Add Graph500 benchmark

### DIFF
--- a/benchkit/benches/graph500/__init__.py
+++ b/benchkit/benches/graph500/__init__.py
@@ -1,0 +1,300 @@
+# Copyright (C) 2024 Vrije Universiteit Brussel. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Graph500 benchmark implementation for benchkit.
+
+Graph500 is a benchmark for large-scale graph traversal and analysis,
+measuring performance using TEPS (Traversed Edges Per Second).
+
+The implementation covers:
+- Fetching Graph500 source from GitHub
+- Building the reference implementation (BFS and BFS+SSSP variants)
+- Running graph generation and traversal benchmarks
+- Parsing TEPS and perfstat metrics from output
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from benchkit.core.bktypes import RecordResult
+from benchkit.core.bktypes.callresults import BuildResult, FetchResult, RunResult
+from benchkit.core.bktypes.contexts import BuildContext, CollectContext, FetchContext, RunContext
+from benchkit.utils.buildtools import build_dir_from_ctx
+from benchkit.utils.dir import get_benches_dir
+from benchkit.utils.fetchtools import git_clone
+
+
+class Graph500Bench:
+    """
+    Benchmark implementation for Graph500.
+
+    Implements the benchkit protocol:
+    - fetch: clone from github
+    - build: compile reference implementation
+    - run: execute graph generation and traversal
+    - collect: parse TEPS and perf stat metrics from output
+    """
+
+    def fetch(
+        self,
+        ctx: FetchContext,
+        parent_dir: Path | None = None,
+        commit: str = "newreference",
+    ) -> FetchResult:
+        """
+        Fetch Graph500 source code from GitHub.
+
+        Args:
+            ctx: FetchContext providing platform and execution capabilities.
+            parent_dir: Directory where the repository will be cloned.
+            commit: Git commit, tag, or branch (default: newreference branch).
+
+        Returns:
+            FetchResult containing the path to the cloned repository.
+        """
+        parent_dir = get_benches_dir(parent_dir=parent_dir)
+
+        graph500_dir = git_clone(
+            ctx=ctx,
+            url="https://github.com/graph500/graph500.git",
+            commit=commit,
+            parent_dir=parent_dir,
+        )
+
+        return FetchResult(src_dir=graph500_dir)
+
+    def build(
+        self,
+        ctx: BuildContext,
+    ) -> BuildResult:
+        """Build the Graph500 reference implementation.
+        Args:
+            ctx: BuildContext providing execution capabilities and build arguments.
+        Returns:
+            BuildResult containing the path to the build directory.
+        """
+
+        platform = ctx.platform
+
+        # copy source to build directory
+        src_dir = ctx.fetch_result.src_dir / "src"
+        build_dir = build_dir_from_ctx(ctx=ctx)
+
+        platform.comm.shell(
+            command=(f"cp -r {src_dir}/. {build_dir}/"),
+            output_is_log=True,
+        )
+
+        # patch the makefile
+        makefile_path = build_dir / "Makefile"
+        makefile = platform.comm.read_file(makefile_path)
+        lines = makefile.splitlines()
+
+        # ensure -fcommon is in CFLAGS to avoid multiple definition errors on newer GCC versions
+        for index, line in enumerate(lines):
+            if line.startswith("CFLAGS"):
+                if "-fcommon" not in line:
+                    lines[index] = line + " -fcommon"
+
+        platform.comm.write_content_to_file(
+            "\n".join(lines),
+            makefile_path,
+        )
+
+        # build the reference implementation (both BFS and BFS+SSSP binaries)
+        ctx.exec(
+            argv=["make", "-j"],
+            cwd=build_dir,
+            output_is_log=True,
+        )
+
+        return BuildResult(build_dir=build_dir)
+
+    def run(
+        self,
+        ctx: RunContext,
+        version: str = "bfs",
+        scale: int = 16,
+        skip_validation: bool = False,
+        edge_factor: int = 16,
+    ) -> RunResult:
+        """Run the Graph500 benchmark with specified parameters.
+        Args:
+            ctx: RunContext providing execution capabilities and run arguments.
+            version: Which binary to run - "bfs" or "bfs_sssp   " (default: "bfs").
+            scale: Scale factor for graph generation (default: 16).
+            skip_validation: Whether to skip validation of results (default: False).
+            edge_factor: Average degree of vertices (default: 16).
+        Returns:
+            RunResult containing the output of the benchmark execution.
+        """
+
+        if version not in ["bfs", "bfs_sssp"]:
+            raise ValueError(f"Invalid version: {version}. " "Must be 'bfs' or 'bfs_sssp'")
+
+        build_dir = ctx.build_result.build_dir
+        validation = "1" if skip_validation else "0"
+        home_dir = os.environ.get("HOME", "/tmp")
+
+        # construct the command to run the benchmark
+        # with appropriate environment variables and arguments
+        command = (
+            f"HOME={home_dir} mpirun -np 1"
+            f" -x HOME"
+            f" -x SKIP_VALIDATION={validation}"
+            f"{version == 'bfs_sssp' and ' -x SKIP_BFS=1' or ''}"
+            f" ./graph500_reference_{version}"
+            f" {scale} {edge_factor}"
+        )
+
+        exec_out = ctx.exec(
+            argv=["bash", "-c", command],
+            cwd=build_dir,
+            output_is_log=True,
+        )
+
+        return RunResult(outputs=[exec_out])
+
+    def collect(self, ctx: CollectContext) -> RecordResult:
+        """Collect and parse the output from the Graph500 benchmark run.
+        Args:
+            ctx: CollectContext providing access to the run results and arguments.
+        Returns:
+            RecordResult containing the parsed metrics from the benchmark output.
+        """
+
+        # parsing from standard output of the benchmark run
+        output = ctx.run_result.outputs[-1].stdout
+
+        parsed: dict[str, Any] = {}
+
+        for line in output.splitlines():
+            if ":" not in line:
+                continue
+            parts = line.split(":")
+            if len(parts) < 2:
+                continue
+            key = "_".join(parts[0].strip().split())
+            value_str = parts[-1].replace("!", "").strip()
+            try:
+                if value_str.lower() == "inf":
+                    parsed[key] = float("inf")
+                elif value_str.lower() == "nan":
+                    parsed[key] = float("nan")
+                elif "." not in value_str and "e" not in value_str.lower():
+                    parsed[key] = int(value_str)
+                else:
+                    parsed[key] = float(value_str)
+            except ValueError:
+                parsed[key] = value_str
+
+        # parsing from the perf stat output if available
+        perf_file = None
+        results_dir = Path.cwd() / "results"  # can be written elsewhere if desired
+        if results_dir.exists():
+            perf_files = list(results_dir.glob("**/perf-stat.txt"))
+            if perf_files:
+                perf_files.sort(key=lambda f: f.stat().st_mtime, reverse=True)
+                perf_file = perf_files[0]
+
+        if perf_file and perf_file.exists():
+            try:
+                with open(perf_file, "r") as f:
+                    for line in f:
+                        if not line.strip():
+                            continue
+                        try:
+                            data = json.loads(line)
+                            event = data.get("event")
+                            val_str = data.get("counter-value", "0")
+                            if event:
+                                parsed[f"perf_{event}"] = float(val_str)
+                        except json.JSONDecodeError:
+                            continue
+
+                if parsed.get("perf_cycles", 0) > 0:
+                    parsed["perf_IPC"] = parsed.get("perf_instructions", 0) / parsed["perf_cycles"]
+
+                if parsed.get("perf_L1-dcache-loads", 0) > 0:
+                    parsed["perf_L1_miss_rate"] = (
+                        parsed.get("perf_L1-dcache-load-misses", 0) / parsed["perf_L1-dcache-loads"]
+                    ) * 100
+
+                if parsed.get("perf_cache-references", 0) > 0:
+                    parsed["perf_cache_miss_rate"] = (
+                        parsed.get("perf_cache-misses", 0) / parsed["perf_cache-references"]
+                    ) * 100
+
+                print(f"[INFO] Successfully parsed perf data from: {perf_file}")
+
+            except Exception as e:
+                print(f"[Warning] Failed to parse perf-stat.txt: {e}")
+        else:
+            print("[Warning] Could not find perf-stat.txt for this run.")
+
+        # keys that are always included, regardless of the used algorithm
+        base_keys = [
+            "SCALE",
+            "edgefactor",
+            "NBFS",
+            "graph_generation",
+            "construction_time",
+            "num_mpi_processes",
+            "min_nedge",
+            "firstquartile_nedge",
+            "median_nedge",
+            "thirdquartile_nedge",
+            "max_nedge",
+            "mean_nedge",
+            "stddev_nedge",
+            "perf_cycles",
+            "perf_instructions",
+            "perf_IPC",
+            "perf_L1-dcache-loads",
+            "perf_L1-dcache-load-misses",
+            "perf_L1_miss_rate",
+            "perf_L1-dcache-stores",
+            "perf_L1-dcache-store-misses",
+            "perf_l2d_cache_rd",
+            "perf_l2d_cache_refill",
+            "perf_cache-references",
+            "perf_cache-misses",
+            "perf_cache_miss_rate",
+            "perf_dTLB-load-misses",
+            "perf_branch-misses",
+            "perf_mem_access_rd",
+            "perf_mem_access_wr",
+        ]
+
+        version = ctx.run_args.get("version", "bfs")
+
+        # construct the record with appropriate keys
+        # based on the version of the benchmark run (BFS or BFS+SSSP)
+        if version == "bfs":
+            record = {k: parsed.get(k) for k in base_keys}
+            record["algorithm"] = "BFS"
+            record["edge_factor"] = ctx.run_args.get("edge_factor")
+            record["min_time"] = parsed.get("bfs_min_time")
+            record["median_time"] = parsed.get("bfs_median_time")
+            record["mean_time"] = parsed.get("bfs_mean_time")
+            record["stddev_time"] = parsed.get("bfs_stddev_time")
+            record["harmonic_mean_TEPS"] = parsed.get("bfs_harmonic_mean_TEPS")
+            record["median_TEPS"] = parsed.get("bfs_median_TEPS")
+            record["harmonic_stddev_TEPS"] = parsed.get("bfs_harmonic_stddev_TEPS")
+            record["mean_validate"] = parsed.get("bfs_mean_validate")
+            return record
+        else:
+            record = {k: parsed.get(k) for k in base_keys}
+            record["algorithm"] = "SSSP"
+            record["edge_factor"] = ctx.run_args.get("edge_factor")
+            record["min_time"] = parsed.get("sssp_min_time")
+            record["median_time"] = parsed.get("sssp_median_time")
+            record["mean_time"] = parsed.get("sssp_mean_time")
+            record["stddev_time"] = parsed.get("sssp_stddev_time")
+            record["harmonic_mean_TEPS"] = parsed.get("sssp_harmonic_mean_TEPS")
+            record["median_TEPS"] = parsed.get("sssp_median_TEPS")
+            record["harmonic_stddev_TEPS"] = parsed.get("sssp_harmonic_stddev_TEPS")
+            record["mean_validate"] = parsed.get("sssp_mean_validate")
+            return record

--- a/tests/benches/test_graph500.py
+++ b/tests/benches/test_graph500.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+# Copyright (C) 2024 Vrije Universiteit Brussel. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""
+Campaign script for Graph500 benchmark with perf analysis.
+
+Demonstrates:
+- Running Graph500 with different scales and versions
+- Using perf command wrapper for performance counters
+"""
+
+from pathlib import Path
+
+from benchkit.benches.graph500 import Graph500Bench
+from benchkit import CampaignCartesianProduct
+from benchkit.campaign import CampaignSuite
+from benchkit.commandwrappers.perf import PerfStatWrap
+from benchkit.utils.dir import get_curdir
+
+
+def graph500_campaign(
+    name: str = "graph500_campaign",
+    src_dir: Path | None = None,
+    results_dir: Path | None = None,
+    nb_runs: int = 5,
+    use_perf: bool = True,
+) -> CampaignCartesianProduct:
+    """
+    Create a Graph500 campaign with multiple configurations.
+
+    Args:
+        name: Campaign name.
+        src_dir: Source directory.
+        results_dir: Output directory for results.
+        nb_runs: Number of runs per configuration.
+        use_perf: Enable perf stat wrapper for hardware counters.
+
+    Returns:
+        Configured campaign ready to run.
+    """
+    bench = Graph500Bench()
+
+    command_wrappers = []
+    if use_perf:
+        perf_wrap = PerfStatWrap(
+            events=[
+                "cycles",
+                "instructions",
+                "L1-dcache-loads",
+                "L1-dcache-load-misses",
+                "L1-dcache-stores",
+                "L1-dcache-store-misses",
+                "l2d_cache_rd",
+                "l2d_cache_refill",
+                "cache-references",
+                "cache-misses",
+                "dTLB-load-misses",
+                "branch-misses",
+                "mem_access_rd",
+                "mem_access_wr",
+            ]
+        )
+        command_wrappers.append(perf_wrap)
+
+    campaign = CampaignCartesianProduct(
+        name=name,
+        benchmark=bench,
+        nb_runs=nb_runs,
+        variables={
+            "version": [
+                "bfs",
+                "bfs_sssp",
+            ],  # bfs_sssp runs bfs_sssp binary but skips bfs kernel to only run sssp
+            "scale": [1, 5, 10, 14, 18, 22],
+            "skip_validation": [True],
+            "edge_factor": [4, 8, 16],
+        },
+        command_wrappers=command_wrappers,
+        results_dir=results_dir,
+    )
+
+    return campaign
+
+
+def main() -> None:
+    """
+    Run Graph500 campaign and generate plots.
+    """
+    results_dir = (get_curdir(__file__) / "results").resolve()  # for easy access to the results
+
+    use_perf = True
+    campaign_basic = graph500_campaign(
+        name="graph500",
+        results_dir=results_dir,
+        nb_runs=2,
+        use_perf=use_perf,
+    )
+
+    campaigns = [campaign_basic]
+    suite = CampaignSuite(campaigns=campaigns)
+
+    suite.print_durations()
+    suite.run_suite()
+
+    edge_palette = {
+        4: "#90e0ef",
+        8: "#00b4d8",
+        16: "#0077b6",
+        32: "#03045e",
+    }
+
+    suite.generate_graph(
+        plot_name="lineplot",
+        x="scale",
+        y="harmonic_mean_TEPS",
+        hue="edge_factor",
+        style="algorithm",
+        palette=edge_palette,
+        ylabel="Harmonic Mean TEPS",
+        xlabel="Scale Factor (2^scale vertices)",
+        title="Graph500 BFS vs SSSP Performance",
+    )
+
+    suite.generate_graph(
+        plot_name="lineplot",
+        x="scale",
+        y="median_TEPS",
+        hue="edge_factor",
+        style="algorithm",
+        palette=edge_palette,
+        ylabel="Median TEPS",
+        xlabel="Scale Factor (2^scale vertices)",
+        title="Graph500 BFS vs SSSP Median TEPS",
+    )
+
+    suite.generate_graph(
+        plot_name="lineplot",
+        x="scale",
+        y="harmonic_stddev_TEPS",
+        hue="edge_factor",
+        style="algorithm",
+        palette=edge_palette,
+        ylabel="Harmonic TEPS Stddev",
+        xlabel="Scale Factor (2^scale vertices)",
+        title="Graph500 BFS vs SSSP TEPS Variability",
+    )
+
+    suite.generate_graph(
+        plot_name="lineplot",
+        x="scale",
+        y="mean_time",
+        hue="edge_factor",
+        style="algorithm",
+        palette=edge_palette,
+        ylabel="Mean Time (s)",
+        xlabel="Scale Factor (2^scale vertices)",
+        title="Graph500 BFS vs SSSP Mean Time",
+    )
+
+    suite.generate_graph(
+        plot_name="lineplot",
+        x="scale",
+        y="stddev_time",
+        hue="edge_factor",
+        style="algorithm",
+        palette=edge_palette,
+        ylabel="Time Stddev (s)",
+        xlabel="Scale Factor (2^scale vertices)",
+        title="Graph500 BFS vs SSSP Time Variability",
+    )
+
+    suite.generate_graph(
+        plot_name="lineplot",
+        x="scale",
+        y="median_time",
+        hue="edge_factor",
+        style="algorithm",
+        palette=edge_palette,
+        ylabel="Median Time (s)",
+        xlabel="Scale Factor (2^scale vertices)",
+        title="Graph500 BFS vs SSSP Median Time",
+    )
+
+    suite.generate_graph(
+        plot_name="lineplot",
+        x="scale",
+        y="graph_generation",
+        hue="edge_factor",
+        style="algorithm",
+        palette=edge_palette,
+        ylabel="Graph Generation Time (s)",
+        xlabel="Scale Factor (2^scale vertices)",
+        title="Graph500 Graph Generation Time by Scale",
+    )
+
+    suite.generate_graph(
+        plot_name="lineplot",
+        x="scale",
+        y="construction_time",
+        hue="edge_factor",
+        style="algorithm",
+        palette=edge_palette,
+        ylabel="Construction Time (s)",
+        xlabel="Scale Factor (2^scale vertices)",
+        title="Graph500 Graph Construction Time by Scale",
+    )
+
+    if use_perf:
+        suite.generate_graph(
+            plot_name="lineplot",
+            x="scale",
+            y="perf_IPC",
+            hue="edge_factor",
+            style="algorithm",
+            palette=edge_palette,
+            ylabel="Instructions Per Cycle (IPC)",
+            xlabel="Scale Factor",
+            title="Graph500 Efficiency (IPC): BFS vs SSSP",
+        )
+
+        suite.generate_graph(
+            plot_name="lineplot",
+            x="scale",
+            y="perf_L1_miss_rate",
+            hue="edge_factor",
+            style="algorithm",
+            palette=edge_palette,
+            ylabel="L1 D-Cache Miss Rate (%)",
+            xlabel="Scale Factor",
+            title="Graph500 L1 Cache Efficiency: BFS vs SSSP",
+        )
+
+        suite.generate_graph(
+            plot_name="lineplot",
+            x="scale",
+            y="perf_cache_miss_rate",
+            hue="edge_factor",
+            style="algorithm",
+            palette=edge_palette,
+            ylabel="LLC Miss Rate (%)",
+            xlabel="Scale Factor",
+            title="Graph500 LLC Efficiency: BFS vs SSSP",
+        )
+
+        suite.generate_graph(
+            plot_name="lineplot",
+            x="scale",
+            y="perf_L1-dcache-load-misses",
+            hue="edge_factor",
+            style="algorithm",
+            palette=edge_palette,
+            ylabel="L1 Load Misses (Count)",
+            xlabel="Scale Factor",
+            title="Graph500 L1 Cache Load Misses",
+        )
+
+        suite.generate_graph(
+            plot_name="lineplot",
+            x="scale",
+            y="perf_L1-dcache-stores",
+            hue="edge_factor",
+            style="algorithm",
+            palette=edge_palette,
+            ylabel="L1 Stores (Count)",
+            xlabel="Scale Factor",
+            title="Graph500 L1 Cache Write Traffic",
+        )
+
+        suite.generate_graph(
+            plot_name="lineplot",
+            x="scale",
+            y="perf_cache-misses",
+            hue="edge_factor",
+            style="algorithm",
+            palette=edge_palette,
+            ylabel="LLC Misses (Count)",
+            xlabel="Scale Factor",
+            title="Graph500 LLC Misses",
+        )
+
+        suite.generate_graph(
+            plot_name="lineplot",
+            x="scale",
+            y="perf_l2d_cache_refill",
+            hue="edge_factor",
+            style="algorithm",
+            palette=edge_palette,
+            ylabel="L2 D-Cache Refills (Count)",
+            xlabel="Scale Factor",
+            title="Graph500 L2 Cache Refills",
+        )
+
+        suite.generate_graph(
+            plot_name="lineplot",
+            x="scale",
+            y="perf_dTLB-load-misses",
+            hue="edge_factor",
+            style="algorithm",
+            palette=edge_palette,
+            ylabel="dTLB Load Misses (Count)",
+            xlabel="Scale Factor",
+            title="Graph500 Data TLB Misses",
+        )
+
+        suite.generate_graph(
+            plot_name="lineplot",
+            x="scale",
+            y="perf_branch-misses",
+            hue="edge_factor",
+            style="algorithm",
+            palette=edge_palette,
+            ylabel="Branch Prediction Misses",
+            xlabel="Scale Factor",
+            title="Graph500 Branch Predictor Performance",
+        )
+
+        suite.generate_graph(
+            plot_name="lineplot",
+            x="scale",
+            y="perf_mem_access_rd",
+            hue="edge_factor",
+            style="algorithm",
+            palette=edge_palette,
+            ylabel="Memory Read Accesses",
+            xlabel="Scale Factor",
+            title="Graph500 Memory Read Intensity",
+        )
+
+        suite.generate_graph(
+            plot_name="lineplot",
+            x="scale",
+            y="perf_mem_access_wr",
+            hue="edge_factor",
+            style="algorithm",
+            palette=edge_palette,
+            ylabel="Memory Write Accesses",
+            xlabel="Scale Factor",
+            title="Graph500 Memory Write Intensity",
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds the Graph500 benchmark and example campaign.

[Graph500](https://github.com/graph500/graph500) is a benchmark designed to evaluate the performance of a system on graph traversal algorithms by measuring the number of traversed edges per second (TEPS). It consists of two main algorithms: Breadth-First Search (BFS) and Single Source Shortest Path (SSSP). For both, the benchmarks generates a synthetic graph based on the Kronecker generator, which creates a power-law graph with a specified scale and edge factor.

Building the benchmark results in two binaries: 
• `graph500_reference_bfs`: runs the Breadth-First Search (BFS) algorithm on a generated graph and measures the TEPS.
• `graph500_reference_bfs_sssp`: runs both the BFS and Single Source Shortest Path (SSSP) algorithms on a generated graph and measures the TEPS for both.
The `graph500_reference_bfs` binary is used to run the BFS algorithm, while the SSSP algorithm is run by using the `graph500_reference_bfs_sssp` binary with a specific flag to only run the SSSP part. This setup is require to correctly distinguish between the BFS and SSSP algorithm; this distinction cannot be achieved by using the `graph500_reference_bfs_sssp` binary alone.