### PR TITLE
Support multiple concurrent benchkit instances

### DIFF
--- a/benchkit/campaign.py
+++ b/benchkit/campaign.py
@@ -32,8 +32,6 @@ from benchkit.utils.misc import get_benchkit_temp_folder_str, seconds2pretty
 from benchkit.utils.types import Constants, PathType, Pretty
 from benchkit.utils.variables import cartesian_product
 
-_BENCHKIT_CAMPAIGN_CMD_FILE = f"{get_benchkit_temp_folder_str()}/benchkit-campaign.sh"
-
 
 class Campaign:
     """
@@ -49,6 +47,7 @@ class Campaign:
         gdb: bool,
         enable_data_dir: bool,
         continuing: bool,
+        tmp_dir: pathlib.Path | None = None,
         symlink_latest: bool = False,
     ):
         self._check_parameters_integrity()
@@ -56,6 +55,9 @@ class Campaign:
         self._enable_data_dir = enable_data_dir
         self._continuing = continuing
         self._symlink_latest = symlink_latest
+        self._campaign_cmd_file = (
+            pathlib.Path(get_benchkit_temp_folder_str(tmp_dir=tmp_dir)) / "benchkit-campaign.sh"
+        )
 
         params: Dict[str, Any] = self.parameters
 
@@ -293,7 +295,7 @@ class Campaign:
             raise ValueError('Campaign parameters dict has no "nb_runs" field.')
 
     def _init_cmd_file(self) -> None:
-        with open(_BENCHKIT_CAMPAIGN_CMD_FILE, "w") as f:
+        with open(self._campaign_cmd_file, "w") as f:
             header = ["#!/bin/sh", "set -e", ""]
             f.writelines(f"{line}\n" for line in header)
 
@@ -301,7 +303,7 @@ class Campaign:
         bdd = self.base_data_dir()
         if bdd is not None:
             dst_path = pathlib.Path(bdd) / "commands.sh"
-            shutil.move(_BENCHKIT_CAMPAIGN_CMD_FILE, dst_path)
+            shutil.move(self._campaign_cmd_file, dst_path)
 
 
 class CampaignSuite:
@@ -509,6 +511,7 @@ class CampaignTemplate(Campaign):
         continuing: bool,
         benchmark_duration_seconds: Optional[int] = None,
         results_dir: Optional[PathType] = None,
+        tmp_dir: pathlib.Path | None = None,
         pretty: Pretty | None = None,
         symlink_latest: bool = False,
     ):
@@ -564,6 +567,7 @@ class CampaignTemplate(Campaign):
             gdb=gdb,
             enable_data_dir=enable_data_dir,
             continuing=continuing,
+            tmp_dir=tmp_dir,
             symlink_latest=symlink_latest,
         )
 
@@ -587,6 +591,7 @@ class CampaignIterateVariables(CampaignTemplate):
         continuing: bool = False,
         benchmark_duration_seconds: Optional[int] = None,
         results_dir: Optional[PathType] = None,
+        tmp_dir: pathlib.Path | None = None,
         pretty: Pretty | None = None,
         symlink_latest: bool = False,
     ):
@@ -602,6 +607,7 @@ class CampaignIterateVariables(CampaignTemplate):
             continuing=continuing,
             benchmark_duration_seconds=benchmark_duration_seconds,
             results_dir=results_dir,
+            tmp_dir=tmp_dir,
             pretty=pretty,
             symlink_latest=symlink_latest,
         )
@@ -627,6 +633,7 @@ class CampaignCartesianProduct(CampaignTemplate):
         continuing: bool = False,
         benchmark_duration_seconds: Optional[int] = None,
         results_dir: Optional[PathType] = None,
+        tmp_dir: pathlib.Path | None = None,
         pretty: Pretty | None = None,
         filter_func: Optional[Callable[[Dict[str, Any]], bool]] = None,
         symlink_latest: bool = False,
@@ -648,6 +655,7 @@ class CampaignCartesianProduct(CampaignTemplate):
             continuing=continuing,
             benchmark_duration_seconds=benchmark_duration_seconds,
             results_dir=results_dir,
+            tmp_dir=tmp_dir,
             pretty=pretty,
             symlink_latest=symlink_latest,
         )

--- a/benchkit/core/compat/new2old.py
+++ b/benchkit/core/compat/new2old.py
@@ -581,6 +581,7 @@ def CampaignIterateVariables(
     post_run_hooks: Iterable[PostRunHook] = (),
     pretty: Pretty | None = None,
     platform: Platform | None = None,
+    tmp_dir: Path | None = None,
 ) -> CampaignIterateVariablesOld:
     """
     Create a legacy iterate-variables campaign for a new-protocol benchmark.
@@ -657,6 +658,7 @@ def CampaignIterateVariables(
         continuing=False,
         benchmark_duration_seconds=duration_s,
         results_dir=results_dir,
+        tmp_dir=tmp_dir,
         pretty=pretty,
         symlink_latest=False,
     )

--- a/benchkit/core/compat/new2old.py
+++ b/benchkit/core/compat/new2old.py
@@ -490,6 +490,7 @@ def CampaignCartesianProduct(
     nb_runs: int = 1,
     duration_s: int | None = None,
     results_dir: Path | None = None,
+    tmp_dir: Path | None = None,
     command_wrappers: Iterable[CommandWrapper] = (),
     command_attachments: Iterable[CommandAttachment] = (),
     shared_libs: Iterable[SharedLib] = (),
@@ -515,6 +516,7 @@ def CampaignCartesianProduct(
         duration_s: Legacy benchmark duration (seconds). Passed to the legacy engine as
             `benchmark_duration_seconds` and forwarded to the new run context as `duration_s`.
         results_dir: Optional base directory for results.
+        tmp_dir: Optional directory where temporary campaign files are stored.
         command_wrappers: Legacy command wrappers (applied via `RunContext.exec` interception).
         command_attachments: Legacy command attachments (not supported).
         shared_libs: Legacy shared libs (applied via `RunContext.exec` interception).
@@ -557,6 +559,7 @@ def CampaignCartesianProduct(
         continuing=False,
         benchmark_duration_seconds=duration_s,
         results_dir=results_dir,
+        tmp_dir=tmp_dir,
         pretty=pretty,
         filter_func=None,
         symlink_latest=False,

--- a/benchkit/utils/misc.py
+++ b/benchkit/utils/misc.py
@@ -6,7 +6,7 @@ Miscellaneous functions.
 
 import datetime
 import getpass
-import os
+import pathlib
 import socket
 import sys
 from time import perf_counter_ns
@@ -123,10 +123,26 @@ def get_user_name() -> str:
     return getpass.getuser()
 
 
-def get_benchkit_temp_folder_str() -> str:
-    path: str = f"/tmp/benchkit-{get_user_name()}"
-    os.makedirs(os.path.dirname(f"{path}/"), exist_ok=True)
-    return path
+def get_benchkit_temp_folder_str(tmp_dir: pathlib.Path | None = None) -> str:
+    """
+    Return the path to the benchkit temporary directory as a string.
+
+    If a temporary directory is explicitly provided, it is used unchanged.
+    Otherwise, the default temporary directory is used:
+
+        /tmp/benchkit-<username>/
+
+    The target directory is created if it does not exist.
+
+    Args:
+        tmp_dir: Optional path overriding the default temporary directory.
+
+    Returns:
+        str: Path to the temporary directory.
+    """
+    path = pathlib.Path(f"/tmp/benchkit-{get_user_name()}") if tmp_dir is None else tmp_dir
+    path.mkdir(parents=True, exist_ok=True)
+    return str(path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request allows per-campaign configuration of a `tmp_dir` instead of using one globally. Currently, all instances of benchkit write to a single global file `benchkit-campaign.sh` which makes running multiple instances yield errors. This prevents me from running benchkit multiple times concurrently on VUB's Hydra cluster.

This pull request adds a new optional argument `tmp_dir` to campaigns in the same style as the existing optional argument `results_dir`.