### PR TITLE
utils/dir: Resolve benches dir on target platform

### DIFF
--- a/benchkit/benches/graph500/__init__.py
+++ b/benchkit/benches/graph500/__init__.py
@@ -54,7 +54,7 @@ class Graph500Bench:
         Returns:
             FetchResult containing the path to the cloned repository.
         """
-        parent_dir = get_benches_dir(parent_dir=parent_dir)
+        parent_dir = get_benches_dir(parent_dir=parent_dir, comm=ctx.platform.comm)
 
         graph500_dir = git_clone(
             ctx=ctx,

--- a/benchkit/benches/heater/sequential/__init__.py
+++ b/benchkit/benches/heater/sequential/__init__.py
@@ -101,7 +101,7 @@ class HeaterSequentialBench:
         Returns:
             FetchResult: contains `src_dir`, the directory holding heaterseq.c.
         """
-        parent_dir = get_benches_dir(parent_dir=parent_dir)
+        parent_dir = get_benches_dir(parent_dir=parent_dir, comm=ctx.platform.comm)
         src_dir = parent_dir / name
         ctx.platform.comm.makedirs(src_dir, exist_ok=True)
 

--- a/benchkit/benches/kyotocabinet/__init__.py
+++ b/benchkit/benches/kyotocabinet/__init__.py
@@ -124,7 +124,7 @@ class KyotoCabinetBench:
                 - src_dir: Path to the extracted and patched KyotoCabinet
                   source directory.
         """
-        parent_dir = get_benches_dir(parent_dir=parent_dir)
+        parent_dir = get_benches_dir(parent_dir=parent_dir, comm=ctx.platform.comm)
 
         platform = ctx.platform
         comm = platform.comm

--- a/benchkit/benches/leveldb/__init__.py
+++ b/benchkit/benches/leveldb/__init__.py
@@ -120,7 +120,7 @@ class LevelDBBench:
         Returns:
             FetchResult containing the path to the cloned repository.
         """
-        parent_dir = get_benches_dir(parent_dir=parent_dir)
+        parent_dir = get_benches_dir(parent_dir=parent_dir, comm=ctx.platform.comm)
 
         leveldb_dir = git_clone(
             ctx=ctx,

--- a/benchkit/benches/rocksdb/__init__.py
+++ b/benchkit/benches/rocksdb/__init__.py
@@ -106,7 +106,7 @@ class RocksDBBench:
         Returns:
             FetchResult containing the path to the cloned repository.
         """
-        parent_dir = get_benches_dir(parent_dir=parent_dir)
+        parent_dir = get_benches_dir(parent_dir=parent_dir, comm=ctx.platform.comm)
 
         rocksdb_dir = git_clone(
             ctx=ctx,

--- a/benchkit/benches/speccpu2017/__init__.py
+++ b/benchkit/benches/speccpu2017/__init__.py
@@ -133,7 +133,7 @@ class SPECCPU2017Bench:
             FetchResult with `src_dir` set to the installed SPEC directory
             (`<parent_dir>/spec`).
         """
-        parent_dir = get_benches_dir(parent_dir=parent_dir)
+        parent_dir = get_benches_dir(parent_dir=parent_dir, comm=ctx.platform.comm)
         spec_dir = parent_dir / "spec-cpu-2017"
         mnt_dir = benchkit_home_dir() / "spec-cpu-2017-mnt"
 

--- a/benchkit/benches/splash4/__init__.py
+++ b/benchkit/benches/splash4/__init__.py
@@ -178,7 +178,7 @@ class Splash4Bench:
         commit: str = SPLASH4_COMMIT,
     ) -> FetchResult:
         """Clone the SPLASH-4 repository (idempotent via git_clone)."""
-        parent_dir = get_benches_dir(parent_dir=parent_dir)
+        parent_dir = get_benches_dir(parent_dir=parent_dir, comm=ctx.platform.comm)
         repo_dir = git_clone(
             ctx=ctx,
             url=SPLASH4_URL,

--- a/benchkit/benches/willitscale/__init__.py
+++ b/benchkit/benches/willitscale/__init__.py
@@ -128,7 +128,7 @@ class WillitscaleBench:
             ... )
         """
 
-        parent_dir = get_benches_dir(parent_dir=parent_dir)
+        parent_dir = get_benches_dir(parent_dir=parent_dir, comm=ctx.platform.comm)
 
         willitscale_dir = git_clone(
             ctx=ctx,

--- a/benchkit/benchmark.py
+++ b/benchkit/benchmark.py
@@ -1161,7 +1161,11 @@ class Benchmark:
         max_nb_digits = len(str(total_nb_runs))
         nb_run_str = f"{run_id:0{max_nb_digits}}"
 
-        dirnames = [f"{k}-{v}" for k, v in record_parameters.items()] + [f"run-{nb_run_str}"]
+        def _safe(value: object) -> str:
+            # a variable value must never spawn nested dirs in the result hierarchy
+            return str(value).replace(os.sep, "_").replace("/", "_")
+
+        dirnames = [f"{k}-{_safe(v)}" for k, v in record_parameters.items()] + [f"run-{nb_run_str}"]
         result = bdd.joinpath(*dirnames).resolve()
 
         if not result.is_dir():

--- a/benchkit/utils/dir.py
+++ b/benchkit/utils/dir.py
@@ -280,7 +280,7 @@ def benchkit_dir() -> pathlib.Path:
     return benchkit_root_dir.resolve()
 
 
-def benchkit_home_dir() -> pathlib.Path:
+def benchkit_home_dir(comm=None) -> pathlib.Path:
     """
     Return the benchkit user home directory.
 
@@ -291,11 +291,26 @@ def benchkit_home_dir() -> pathlib.Path:
       1. If BENCHKIT_HOME is set in the environment, use it.
       2. Otherwise, default to ~/.benchkit/
 
+    When ``comm`` is provided, resolution happens on the **target** platform
+    (its ``$HOME`` / ``BENCHKIT_HOME``), not the orchestrator's, so that a remote
+    host with a different home directory gets a valid path. Without ``comm``, the
+    local machine is used.
+
     The directory may not necessarily exist yet.
+
+    Args:
+        comm: Optional communication layer of the target platform.
 
     Returns:
         pathlib.Path: Absolute path to the benchkit home directory.
     """
+    if comm is not None:
+        out = comm.shell(
+            command=["sh", "-lc", "echo ${BENCHKIT_HOME:-$HOME/.benchkit}"],
+            output_is_log=False,
+        ).strip()
+        return pathlib.Path(out)
+
     env = os.environ.get("BENCHKIT_HOME")
     if env:
         return pathlib.Path(env).expanduser().resolve()
@@ -303,7 +318,7 @@ def benchkit_home_dir() -> pathlib.Path:
     return pathlib.Path("~/.benchkit").expanduser().resolve()
 
 
-def get_benches_dir(parent_dir: pathlib.Path | None) -> pathlib.Path:
+def get_benches_dir(parent_dir: pathlib.Path | None, comm=None) -> pathlib.Path:
     """
     Return the directory where benchmark sources are stored.
 
@@ -312,15 +327,20 @@ def get_benches_dir(parent_dir: pathlib.Path | None) -> pathlib.Path:
 
         ~/.benchkit/benches/
 
+    When ``comm`` is provided, the default is resolved on the **target** platform
+    (see :func:`benchkit_home_dir`), so remote fetches land under the target's
+    own home directory rather than the orchestrator's.
+
     Args:
         parent_dir: Optional path overriding the default benches directory.
+        comm: Optional communication layer of the target platform.
 
     Returns:
         pathlib.Path: Path to the directory containing benchmark sources.
     """
-    if parent_dir is None:
-        return benchkit_home_dir() / "benches"
-    return parent_dir
+    if parent_dir is not None:
+        return parent_dir
+    return benchkit_home_dir(comm=comm) / "benches"
 
 
 def get_results_dir(results_dir: pathlib.Path | None) -> pathlib.Path:


### PR DESCRIPTION
benchkit_home_dir()/get_benches_dir() resolved ~/.benchkit from the orchestrator's home even for remote runs, so a target host with a different $HOME (e.g. /u/user vs /home/user) got an invalid path and fetch failed. They now accept a `comm` and resolve $HOME/BENCHKIT_HOME on the target platform; all benches pass `comm=ctx.platform.comm`.

Also harden the result-directory hierarchy: sanitize path separators in `<var>-<value>` component names, so a path-valued variable can no longer spawn a spurious nested subtree.